### PR TITLE
Update add-to-project action version

### DIFF
--- a/.github/workflows/auto-add-issues.yml
+++ b/.github/workflows/auto-add-issues.yml
@@ -8,7 +8,7 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e
         with:
           project-url: https://github.com/orgs/ripmarkus/projects/5
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
hash pinned to 1.0.1

### What has changed?

v1 changed to v1.0.1

### Why did it need to be changed?

an error in github actions section

### How did you change it?

i hash pinned the the action add-to-project in the auto-add-issues.yml
***

**Checklist**

- [✅] Application compiles
- [✅] Documentation added
