### PR TITLE
Fix/ci workflow

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,3 @@ Style/FrozenStringLiteralComment:
 
 Naming/MethodParameterName:
   MinNameLength: 3
-
-AllCops
-  NewCops: enable  


### PR DESCRIPTION
### What has changed?

The ruby-ci workflow file.

### Why did it need to be changed?

It could not locate the ruby app or gemfile so it failed - also it couldn't locate the ruby version either.

### How did you change it?

I added explicit ruby version and working-directory.

***

**Checklist**

- [ ] Application compiles
- [ ] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes CI workflow failures by establishing explicit Ruby configuration and working directory context. The changes are pragmatic and resolve the immediate issue, but introduce some concerns worth addressing.

## Key Changes

- Added `defaults.run.working-directory: ruby-app` to set context for all steps
- Hardcoded Ruby version from `.ruby-version` to `'3.2'`
- Updated RuboCop report path reference to `ruby-app/rubocop.md` to account for working directory context

## Feedback

**Working directory duplication**: The `working-directory: ruby-app` is specified twice—once in `defaults.run` (line 11) and again in the `ruby/setup-ruby` action (line 18). Remove the redundant declaration in the action; the defaults apply globally.

```yaml
- uses: ruby/setup-ruby@v1
  with:
    ruby-version: '3.2'
    bundler-cache: true
    # Remove working-directory here—defaults already set it
```

**Missing `.ruby-version` file**: Rather than hardcoding `'3.2'`, create a `.ruby-version` file at the repository root with `3.2` as content. This is a standard Ruby practice that makes the version explicit in version control and usable by local development tools (rbenv, asdf, etc.). This improves consistency across CI and developer environments.

**Path clarity in github-script step**: Line 27 looks for `ruby-app/rubocop.md` while line 20 outputs to `rubocop.md` (relative to the working directory). This works because github-script runs at the repo root, but the inconsistency is subtle. Either document this clearly in a comment, or consider outputting to an absolute path for clarity.

## DevOps Perspective

From an **Automation** and **Measurement** angle: hardcoding the Ruby version reduces flexibility. Using a `.ruby-version` file enables version management as code and lets local development and CI stay in sync. This is especially valuable in an educational context where consistency across environments helps students learn proper DevOps practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->