### PR TITLE
Added markdown file for openapi

### DIFF
--- a/documentation/open-api.md
+++ b/documentation/open-api.md
@@ -1,0 +1,33 @@
+## OpenAPI Documentation
+
+### Purpose
+We want all developers to have a clear overview of our API and page endpoints, so we have an overview on the site itself.
+
+### HTML Routes
+The specification also documents routes used for rendering pages in the browser:
+
+- `/` – Main page. Supports the parameters `query` and `language`.
+- `/about` – Page containing information about the project.
+- `/login` – Page used for user login.
+- `/register` – Page used for creating a new account.
+- `/weather` – Displays weather data based on `city` and `country`.
+
+### API Endpoints
+The API routes are defined under the `/api` path.
+
+- `GET /api/users` – Returns user data.
+- `GET /api/search` – Performs a search based on `query` and `language`.
+- `GET /api/weather` – Returns weather information for a specified location.
+
+### Authentication Endpoints
+User authentication is handled through the following endpoints:
+
+- `POST /api/register` – Registers a new user.
+- `POST /api/login` – Authenticates a user.
+- `POST /api/logout` – Ends the user session.
+
+### Interactive Documentation
+The specification is visualized using **Swagger UI**.
+The documentation is available locally at:
+
+`http://91.100.1.101/api/docs`


### PR DESCRIPTION
### What has changed?
Added a markdown file for our openapi 

### Why did it need to be changed?
We wanted to give our developers an overview of the site on the site.

### How did you change it?
By adding a markdown file.

***

**Checklist**

- [ ] Application compiles
- [x] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## OpenAPI Documentation Review

### Security Concern: Hardcoded IP Address
The documentation contains a hardcoded IP address (`http://91.100.1.101/api/docs`) that appears to be an internal staging/development server. **This should be removed or replaced with a placeholder** — embedding specific infrastructure IPs in version control creates security and maintenance issues:
- It exposes internal network topology
- It breaks when infrastructure changes
- It may accidentally leak staging/production differences

**Suggestion**: Use a placeholder like `http://[your-domain]/api/docs` or document the local development URL separately (e.g., `http://localhost:8000/api/docs` for development).

### Documentation Format Gap
This file is titled "OpenAPI Documentation" but doesn't contain an actual OpenAPI specification (YAML or JSON format). The current markdown format is helpful for humans but misses the machine-readable spec that tools, API clients, and automated testing frameworks need. **For a proper DevOps workflow** (automation & measurement principles):
- Generate an OpenAPI spec file (YAML/JSON) from your code or manually define one
- Use tools like Swagger Codegen or OpenAPI validators to keep it in sync
- Let Swagger UI auto-generate from the actual spec rather than manual documentation

### Incomplete API Documentation
Key details are missing that developers need:
- **Parameter types** (string, integer, boolean, etc.)
- **Required vs optional** parameters
- **Response formats** and status codes (200, 400, 401, 500, etc.)
- **Error responses** — what happens when something fails?
- **Authentication scheme** — how are tokens passed? (Bearer header, cookie, etc.)

Example: `/api/search` accepts `query` and `language`, but are they required? What's the format? What if both are missing?

**These gaps make the documentation fragile and harder to maintain** — it's essentially promise-based rather than spec-based.

### Recommendation
For a DevOps education project, this is a learning opportunity: **Implement a proper OpenAPI specification** (start with `openapi.yaml` or `openapi.json` at the project root) and generate documentation from it. This aligns with automation and sharing principles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->