### PR TITLE
Port changed from 4567 to 80

### DIFF
--- a/ruby-app/OpenAPI/OpenAPI.yaml
+++ b/ruby-app/OpenAPI/OpenAPI.yaml
@@ -4,7 +4,7 @@ info:
   version: 1.0.0
   description: Whoknows Sinatra app - HTML routes and API endpoints
 servers:
-  - url: http://localhost:4567
+  - url: http://localhost:80
 paths:
   /:
     get:


### PR DESCRIPTION

### What has changed?
the container is exposed on port 80 instead of 4567

### Why did it need to be changed?

to support actual deployment of the application

### How did you change it?
changed the openapi.yaml file for proper endpoint.
***

**Checklist**

- [ ] Application compiles
- [ ] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Configuration Mismatch – Incomplete Port Migration

This PR updates the OpenAPI specification to port 80, but this creates a critical inconsistency in the deployment configuration:

**What's wrong:**
- The Dockerfile still `EXPOSE 4567`, which is outdated
- The app actually runs on port **8080** (see `CMD ["ruby", "app.rb", "-o", "0.0.0.0", "-p", "8080"]`)
- The OpenAPI spec now declares port 80, which doesn't match the actual running port

**Why this matters (DevOps Lean & Automation):**
Configuration management requires consistency across all artifacts. When documentation, container directives, and application specs declare different ports, operators and automation tools cannot reliably route traffic or health-check the service.

**What needs to change:**
1. Update `ruby-app/Dockerfile` to `EXPOSE 8080` (matching the actual CMD port)
2. Update `ruby-app/OpenAPI/OpenAPI.yaml` to `http://localhost:8080` (matching actual deployment)
3. Update `ruby-app/ruby-documentation/docker.md` to reflect the correct port in EXPOSE

This PR should have included all three changes in a single commit to maintain consistency across build, deployment, and documentation artifacts.

**Suggestion:**
Before merging, please verify:
- What is the actual target port for production deployment?
- Is it truly port 80, or should it be 8080?
- Update all references (Dockerfile EXPOSE, OpenAPI spec, documentation) to match that single source of truth

<!-- end of auto-generated comment: release notes by coderabbit.ai -->