### PR TITLE
Fixed password checker to not accept empty strings or spaces and more

### DIFF
--- a/ruby-app/app.rb
+++ b/ruby-app/app.rb
@@ -174,9 +174,8 @@ def validate_registration(db, params)
   error = validate_registration_fields(params)
   return error if error
 
-return 'The username already exists' if get_user_id(db, params[:username])
-return 'The email already exists' if db.execute('SELECT 1 FROM users WHERE email = ? LIMIT 1', [params[:email]]).first
-
+  return 'The username already exists' if get_user_id(db, params[:username])
+  'The email already exists' if db.execute('SELECT 1 FROM users WHERE email = ? LIMIT 1', [params[:email]]).first
 end
 post '/api/register' do
   redirect '/' if session[:user_id]


### PR DESCRIPTION
### What has changed?
The def validate_registration_fields(params) and def validate_registration(db, params).

### Why did it need to be changed?
Because a password could be filled out as an empty string or just spaces.

### How did you change it?
By changing .nill? to .to_s.strip.empty? And added an email check:
return 'The email already exists' if db.execute('SELECT 1 FROM users WHERE email = ? LIMIT 1', [params[:email]]).first


***

**Checklist**

- [X] Application compiles
- [ ] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR tightens registration validation: it rejects passwords that are empty or only whitespace and adds an email-existence check to prevent duplicate emails.

## Changes

- Password validation: validate_registration_fields now uses params[:password].to_s.strip.empty? to reject nil, empty, or whitespace-only passwords.
- Email uniqueness: validate_registration added a check that returns an error when the email already exists in the users table via a parameterized SELECT.

## Issues & Concerns

- Inconsistent return style / possible clarity bug in validate_registration:
  - The username check uses an explicit conditional return:
    return 'The username already exists' if get_user_id(db, params[:username])
  - The email check is written as an expression (no explicit return):
    'The email already exists' if db.execute('SELECT 1 FROM users WHERE email = ? LIMIT 1', [params[:email]]).first
  This works in Ruby (last expression returned) but is inconsistent and less clear. Prefer an explicit return for readability and to avoid accidental fall-through.

- Password confirmation trimming (logic edge case):
  - validate_registration_fields compares params[:password] != params[:password2] without trimming. If a user submits password "pass" and password2 " pass" (leading/trailing spaces), they will be treated as different. Consider trimming both sides before comparison or explicitly documenting that whitespace is significant.

- Minor inconsistency in parameter passing:
  - get_user_id uses db.execute('SELECT id FROM users WHERE username = ?', username) (single arg, not array). Other db.execute calls pass args as arrays ([...]). Keep the parameter style consistent to avoid surprises across adapters.

- DevOps / commit granularity check:
  - The change set appears small (few lines in a single file). No indication of large unrelated files in this PR from the inspected file; if the actual commit includes many unrelated files, split into focused commits. (Based on provided summary: lines changed +3/-2, files changed likely 1 — no atomic-commit problem here.)

## Security

- Good: Queries use parameter binding for SQL, protecting against SQL injection in the shown changes.
- Recommend: Consider adding a unique constraint on the users.email column at the database level to guarantee uniqueness even under race conditions (application-level check alone can be bypassed with concurrent requests).

## Suggestions (GitHub suggestion format)

- Make email check an explicit return for clarity:
```suggestion
def validate_registration(db, params)
  error = validate_registration_fields(params)
  return error if error

  return 'The username already exists' if get_user_id(db, params[:username])
  return 'The email already exists' if db.execute('SELECT 1 FROM users WHERE email = ? LIMIT 1', [params[:email]]).first
end
```

- Trim both passwords before comparing:
```suggestion
def validate_registration_fields(params)
  return 'You have to enter a username' if params[:username].nil? || params[:username].empty?
  return 'Valid email address needed' if params[:email].nil? || !params[:email].include?('@')
  return 'You have to enter a password' if params[:password].to_s.strip.empty?

  return 'The two passwords do not match' if params[:password].to_s.strip != params[:password2].to_s.strip
end
```

- (Optional) Normalize parameter style when calling db.execute/get_user_id:
```suggestion
def get_user_id(db, username)
  row = db.execute('SELECT id FROM users WHERE username = ?', [username]).first
  row ? row[0] : nil
end
```

## Positive Notes

- Good use of .to_s.strip.empty? to close the whitespace-only password gap.
- SQL parameterization is used correctly in the new check.
- Small, focused logic changes that improve validation and user feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->