### PR TITLE
tilføjet yaml til dokumentation

### DIFF
--- a/documentation/mandatory-1/mandatory-1.md
+++ b/documentation/mandatory-1/mandatory-1.md
@@ -163,6 +163,141 @@ User authentication is handled through the following endpoints:
 - `POST /api/login` – Authenticates a user.
 - `POST /api/logout` – Ends the user session.
 
+## Generation
+
+```yaml
+openapi: 3.0.0
+info:
+  title: Whoknows - HTML + API
+  version: 1.0.0
+  description: Whoknows Sinatra app - HTML routes and API endpoints
+servers:
+  - url: http://localhost:80
+paths:
+  /:
+    get:
+      summary: GET /
+      parameters:
+        - name: query
+          in: query
+          schema:
+            type: string
+          example: test
+        - name: language
+          in: query
+          schema:
+            type: string
+          example: en
+      responses:
+        default:
+          description: GET /
+      tags:
+        - HTML
+  /about:
+    get:
+      summary: GET /about
+      responses: {}
+      tags:
+        - HTML
+  /login:
+    get:
+      summary: GET /login
+      responses: {}
+      tags:
+        - HTML
+  /register:
+    get:
+      summary: GET /register
+      responses: {}
+      tags:
+        - HTML
+  /weather:
+    get:
+      summary: GET /weather
+      parameters:
+        - name: city
+          in: query
+          schema:
+            type: string
+          example: København
+        - name: country
+          in: query
+          schema:
+            type: string
+          example: DK
+      responses:
+        default:
+          description: GET /weather
+      tags:
+        - HTML
+  /api/users:
+    get:
+      summary: GET /api/users
+      responses: {}
+      tags:
+        - API
+  /api/search:
+    get:
+      summary: GET /api/search
+      parameters:
+        - name: query
+          in: query
+          schema:
+            type: string
+          example: test
+        - name: language
+          in: query
+          schema:
+            type: string
+          example: en
+      responses:
+        default:
+          description: GET /api/search
+      tags:
+        - API
+  /api/weather:
+    get:
+      summary: GET /api/weather
+      parameters:
+        - name: city
+          in: query
+          schema:
+            type: string
+          example: København
+        - name: country
+          in: query
+          schema:
+            type: string
+          example: DK
+      responses:
+        default:
+          description: GET /api/weather
+      tags:
+        - API
+  /api/register:
+    post:
+      summary: POST /api/register
+      responses:
+        default:
+          description: POST /api/register
+      tags:
+        - API
+  /api/login:
+    post:
+      summary: POST /api/login
+      responses:
+        default:
+          description: POST /api/login
+      tags:
+        - API
+  /api/logout:
+    post:
+      summary: POST /api/logout
+      responses: {}
+      tags:
+        - API
+ ```
+
 
 ---
 


### PR DESCRIPTION
### What has changed?
added yaml to mandatory1 file

### Why did it need to be changed?

we need to hand in an openapi specification

### How did you change it?
by adding it to the markdown file for our mandatory 1 assignment.

***

**Checklist**

- [ ] Application compiles
- [ ] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Documentation Duplication

The OpenAPI YAML specification is duplicated in the document—it appears once under the "Authentication Endpoints" section and again under "Our OpenAPI" section. This violates DRY principles and creates maintenance burden: any updates to the spec must be made in two places, increasing the risk of inconsistencies. Consider consolidating this into a single location or extracting it to a separate, reusable file that can be referenced or embedded.

## Commit Atomicity

This PR adds 135 lines of content in a single commit. For better maintainability and reviewability, consider splitting this into more atomic commits—for example:
- One commit for the OpenAPI documentation structure and explanation
- One commit for the YAML specification itself
- Separate commits for other major sections if applicable

This makes it easier to track what changed and why, and aligns with DevOps principles around **Measurement** and **Sharing** by maintaining clear, reviewable history.

## Documentation Quality

The documentation provides good context around the OpenAPI specification (purpose, generation method, rationale for YAML format). However, ensure the spec itself stays synchronized with the actual API implementation as it evolves—consider automating spec generation from code if possible, or establishing a process to validate the spec against running endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->