### PR TITLE
Docu/fixyaml

### DIFF
--- a/documentation/mandatory-1/mandatory-1.md
+++ b/documentation/mandatory-1/mandatory-1.md
@@ -136,7 +136,7 @@ The route /api/docs is an on premise Swagger/OpenAPI UI. The purpose it serves i
 
 ![OpenAPI](../imgs/OpenAPIpage.png)
 ## Generation
-The OpenAPI specification was generated using Postman. All of our routes were added to a Postman collection. Examples were also added for almost every possible endpoint. The OpenAPI specification was generated shortly after this, using the `Generate Specification` feature.
+The OpenAPI specification was generated using Postman. All of our routes were added to a Postman collection. Examples were also added for almost every possible endpoint. The OpenAPI specification was generated shortly after this, using the `Generate Specification` feature. 
 
 Postman can generate specifications in two different outputs, one being YAML and the other being JSON. YAML is easier for humans to read, which lead us to the conclusion of using YAML.
 


### PR DESCRIPTION
### What has changed?

header was changed for openapi specification

### Why did it need to be changed?

look stupid

### How did you change it?

change title

***

**Checklist**

- [ ] Application compiles
- [ ] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR renames a documentation section header from "## Generation" to "## OpenAPI Specification" to improve document structure clarity. A minor trailing whitespace was also added.

## Feedback

**PR Description**: The reasoning "header look stupid" is informal and vague. For a learning-focused team, use concrete language that helps reviewers understand the improvement:
- Is the new name clearer for developers onboarding to your API?
- Does it better reflect the section's content?

Clear rationale helps the team learn *why* documentation matters and sets a professional standard.

**Good Structural Improvement**: The change makes sense architecturally. You now have:
- "## Generation" → explains *how* the spec was created (methodology)
- "## OpenAPI Specification" → contains the *actual* spec (deliverable)

This separation supports the "Sharing" principle in CALMS by making it easier for developers to find what they need.

**Maintenance Consideration**: Since this OpenAPI spec was generated from Postman (as documented), ensure your team has a defined process for keeping it in sync with code changes. Document whether developers should regenerate it when adding endpoints, or if there's a CI/CD step that validates it. Avoiding spec drift prevents confusion and maintains trust in your documentation.

**Unchecked Checklist**: Same note as before—clarify whether your checklist items ("Application compiles", "Documentation added") should be checked before submitting, or if they're aspirational. For a documentation-only PR, explicitly state why compilation verification isn't applicable here.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->