### PR TITLE
Added the yaml for the CD-workflow

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -1,0 +1,34 @@
+name: Deployment
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Ruby CI"]
+    types:
+      - completed
+    branches:
+      - development
+
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH deploy
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SERVER_IP }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script_stop: true
+          script: |
+            set -eux
+
+            # Login to GHCR (no token printed)
+            echo '${{ secrets.GHCR_TOKEN }}' | docker login ghcr.io -u '${{ secrets.GHCR_USERNAME }}' --password-stdin
+
+            cd /opt/docker/devops/whoknows_ripmarkus/ruby-app
+            docker compose down
+            docker compose pull
+            docker compose up -d


### PR DESCRIPTION
### What has changed?
Kristian added the CD.yaml file to the project.

### Why did it need to be changed?
Because there is no automation yet,

### How did you change it?
by adding a Continous Deployment workflow.
***

**Checklist**

- [x ] Application compiles
- [ ] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CD Workflow Implementation Review

### What's Working Well
✓ **Automation implemented** - Successfully adds continuous deployment automation as the objective states  
✓ **Gated deployment** - Properly gates deployment on successful CI completion (`if: ${{ github.event.workflow_run.conclusion == 'success' }}`)  
✓ **Secure credential handling** - Uses `--password-stdin` for GHCR login to avoid token exposure in command args; developer awareness shown in code comment  
✓ **Strict shell behavior** - `set -eux` ensures errors fail the workflow and visibility of what's executing  

### Security & DevOps Concerns

**Token exposure risk with `set -eux`:**  
Line 29 pipes the GHCR token into `docker login`. While `--password-stdin` is correct, the preceding `echo` command with the token may still appear in logs when `set -x` (debug mode) is enabled, depending on GitHub Actions' secret redaction. Test deployment logs to confirm the echo line is properly redacted. Consider wrapping in a subshell or using safer patterns:
```yaml
docker login ghcr.io -u '${{ secrets.GHCR_USERNAME }}' --password-stdin <<< '${{ secrets.GHCR_TOKEN }}'
```

**Service downtime during deployment:**  
`docker compose down` + `docker compose up -d` causes complete service unavailability. For a DevOps elective project, consider demonstrating zero-downtime deployment patterns:
```yaml
docker compose up -d --no-deps --build  # Recreates only changed services
```
Or add health checks to verify service readiness before completing the workflow.

**Missing deployment verification:**  
No confirmation that services actually started successfully after `docker compose up -d`. The deployment workflow completes when the command returns, but doesn't validate the application is healthy. Add a verification step:
```yaml
sleep 5 && docker compose ps | grep -q "healthy\|running" || exit 1
```

**Hardcoded path and limited observability:**  
- The deployment path `/opt/docker/devops/whoknows_ripmarkus/ruby-app` is hardcoded; no environment variables for configuration management
- No logging, notifications, or metrics on deployment status (Measurement principle)

### Suggestions for DevOps Growth

1. **Add deployment verification** - Validate service health before marking deployment as successful
2. **Implement minimal-downtime strategy** - Update to selective container recreation to avoid downtime
3. **Add observability** - Log deployment start/end, send notifications on success/failure (Sharing & Measurement principles)
4. **Configuration management** - Move hardcoded paths and credentials to repository variables for flexibility across environments

**Atomic commits:** Single +34 line addition is appropriately granular.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->