### PR TITLE
Changed branches from development to main

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -7,7 +7,7 @@ on:
     types:
       - completed
     branches:
-      - development
+      - main
 
 
 jobs:


### PR DESCRIPTION
### What has changed?
changed branch from dev to main

### Why did it need to be changed?
skipped workjflow


### How did you change it?
changing branch in cd.yaml file.
***

**Checklist**

- [ ] Application compiles
- [ ] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
This PR updates the Continuous Deployment workflow to deploy from `main` branch instead of `development`. The workflow is triggered on successful completion of the "Ruby CI" workflow, and the deployment script uses SSH to pull the latest Docker images and restart the application.

## DevOps Context
The change aligns the deployment pipeline with a main-branch deployment strategy, which is appropriate for continuous deployment workflows. However, the PR lacks context explaining the motivation for this branch strategy shift—was `development` not stable? Is `main` now your production-ready branch? This understanding is important for the team's shared DevOps culture.

## Observations
- **Minimal PR description**: The PR provides no explanation beyond the branch name change. For a DevOps team, documenting *why* deployment branch strategies change is valuable for knowledge sharing and prevents future confusion.
- **Incomplete checklist**: Both checklist items ("Application compiles", "Documentation added") are unchecked. Clarify whether these apply to this workflow change or if the checklist should be adjusted for infrastructure/workflow PRs.
- **Atomic commits**: The change is appropriately sized (1 commit, 1 file).

## Recommendation
Before merging, consider updating the PR description to explain: Why the shift from `development` to `main`? Does your team now follow a strategy where `main` is always deployment-ready? This brief context helps reviewers understand the deployment strategy and serves as documentation for future team members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->