### PR TITLE
docs: Updated the CI/CD documentation to reflect our current workflows

### DIFF
--- a/documentation/ci-cd.md
+++ b/documentation/ci-cd.md
@@ -1,6 +1,6 @@
 # CI/CD
 
-## CI
+## CI (OLD)
 
 At the time of writing, our CI checks focus on compiling the app and linting the code using RuboCop, configured via a .rubocop.yml in the project root. This file defines our code style and complexity rules, ensuring consistent standards are enforced on every PR created.
 
@@ -14,6 +14,21 @@ By enforcing these steps, we ensure that every Pull Request meets our baseline s
 
 Running Ruboco locally is definitely a possibility, however running it in our CI flow, allows all developers to see what can be done better with our code quality, before they can submit the code - This nudges our team to fix issues instead of only fixing issues when they become a bigger problem.
 
+## CI (NEW)
+
+The CI-pipeline runs on every push and pull request to `main`, and can also be triggered manually via `workflow_dispatch`.
+
+The first job (**Docker Build**) builds the Docker image from `ruby-app/Dockerfile`. Once built, a container is spun up and a health check is performed. The database is initialized and a request is made to the app to verify it's running correctly. If any of this fails, the pipeline stops, ensuring broken code won't make it further.
+
+If the build and health check pass, and the trigger was not a pull request, the next job (**Docker Push**) pushes the image to GHCR. This ensures only verified images are published, ready for the CD-pipeline to deploy. 
+
 ## CD
 
-To be added.
+The CD-pipeline triggers automatically when the CI workflow completes successfully on `main`, or can be triggered manually via `workflow_dispatch`.
+
+Deployment steps:
+
+1. An SSH key is added to the runner from repository secrets
+2. The runner SSH's into the production server
+3. The server logs into GHCR and pulls the latest Docker image
+4. The running container is stopped, and restarted with the new image via Docker Compose


### PR DESCRIPTION
### What has changed?

The CI/CD documentation now reflects the current workflows.

### Why did it need to be changed?

The old CI documentation described RuboCop linting (maybe make a documentation for the RubyCop?), but the CI pipeline had since been updated to use Docker builds and health checks.

### How did you change it?
Rewrote the CI section to describe the Docker build, health check, and push jobs, and added a CD section documenting the automated deployment flow.

***

**Checklist**

- [ ] Application compiles
- [x] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the CI/CD documentation to reflect modern workflows using Docker builds and automated deployment, replacing legacy RuboCop-only checks with containerized health checks and GHCR image pushes. While the documentation accurately describes the Docker-based CI/CD flows, there are clarity and completeness issues worth addressing.

## Issues & Feedback

### Documentation Accuracy
The CI and CD workflows are documented correctly and match the actual `CI.yaml` and `CD.yaml` files. However, **the "CI (OLD)" framing is misleading**: the RuboCop workflow (`rubocop.yaml`) is still actively running on PRs (filtered to `app.rb` changes). Rather than positioning RuboCop as "old," clarify that **two CI checks run in parallel**:
- RuboCop: Fast, style/quality linting on code changes
- Docker CI: Full integration testing with build and health checks

This prevents developers from assuming RuboCop checks have been removed.

### Missing Context
The documentation would benefit from explaining:

1. **Why the shift?** What problem does Docker-based CI solve that RuboCop alone doesn't? (e.g., "RuboCop checks style, but Docker CI verifies the app actually runs and responds to requests")

2. **Deployment details**: The CD section jumps to "docker compose pull/down/up" without context. Where does the compose file live? What services run? This matters for understanding deployment safety.

3. **Database initialization**: The CI health check runs `init_db.rb`, but the CD doesn't. Is the database already initialized on the production server, or does it skip this step intentionally? Document this assumption.

### Security Concern
The CD workflow uses:
```yaml
ssh -i ~/.ssh/homeserver -o StrictHostKeyChecking=no ...
```

**`StrictHostKeyChecking=no` disables host key verification**, making deployments vulnerable to man-in-the-middle attacks if the SSH connection is intercepted. Instead, add the production server's public key to `known_hosts` or use a GitHub secret containing the host key. Document why this matters: "Without verification, an attacker could intercept the SSH connection and compromise the deployment."

### Suggestion: Document DevOps Principles
Per your course focus, briefly explain the workflow design choices using DevOps principles:
- **Automation**: All testing and deployment triggered automatically
- **Lean**: Docker Push skips on PRs (saves registry bandwidth/storage)
- **Measurement**: Consider adding what you'd monitor post-deployment (app responsiveness, error rates)

## Checklist Item
The PR description marks "Documentation added" as unchecked—this should be checked since the documentation is indeed added/updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->