### PR TITLE
Feat/fts5

### DIFF
--- a/documentation/fts5.md
+++ b/documentation/fts5.md
@@ -1,0 +1,25 @@
+# SQLite FTS5
+
+## What changed
+Replaced the `LIKE` operator with FTS5 (Full Text Search 5) for page searches.
+
+## How it works
+- A virtual table `pages_fts` mirrors the `pages` table
+- Triggers on `pages` keep `pages_fts` in sync (insert, update, delete)
+- Search queries use `MATCH` instead of `LIKE` and results are ranked by relevance
+
+## LIKE vs FTS5
+
+| | LIKE | FTS5 |
+|---|------|------|
+| Speed | Slow on large tables (full scan) | Fast (inverted index) |
+| Relevance ranking | No | Yes (built-in `rank`) |
+| Setup | None | Requires virtual table + triggers |
+| Partial matches | Yes (`%word%`) | No (matches whole tokens) |
+| Storage | No extra | Extra index table |
+
+## SQLite limitations
+- No concurrent writes (single-writer lock)
+- No built-in replication
+- Not suitable for high-traffic multi-server setups
+- FTS5 may not be enabled in all SQLite builds (needs compile-time flag)

--- a/ruby-app/app.rb
+++ b/ruby-app/app.rb
@@ -115,10 +115,16 @@ end
 ###############
 
 def search_pages_query(db, language, query)
-  sql = 'SELECT * FROM pages WHERE language = ? AND lower(title) LIKE lower(?)'
+  sql = <<~SQL
+    SELECT p.title, p.url, p.language, p.last_updated, p.content
+    FROM pages p
+    JOIN pages_fts ON pages_fts.title = p.title
+    WHERE pages_fts MATCH ? AND p.language = ?
+    ORDER BY rank
+  SQL
   pages = []
 
-  db.execute(sql, [language, "%#{query.to_s.strip}%"]) do |row|
+  db.execute(sql, [query.to_s.strip, language]) do |row|
     title, url, language, last_updated, content = row
     pages << { title: title, url: url, language: language, last_updated: last_updated, content: content }
   end

--- a/ruby-app/init_db.rb
+++ b/ruby-app/init_db.rb
@@ -24,6 +24,23 @@ schema = <<~SQL
     last_updated TIMESTAMP,
     content TEXT NOT NULL
   );
+
+  DROP TABLE IF EXISTS pages_fts;
+
+  CREATE VIRTUAL TABLE pages_fts USING fts5(title, content, language, content='pages', content_rowid='rowid');
+
+  CREATE TRIGGER IF NOT EXISTS pages_ai AFTER INSERT ON pages BEGIN
+    INSERT INTO pages_fts(rowid, title, content, language) VALUES (new.rowid, new.title, new.content, new.language);
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS pages_ad AFTER DELETE ON pages BEGIN
+    INSERT INTO pages_fts(pages_fts, rowid, title, content, language) VALUES('delete', old.rowid, old.title, old.content, old.language);
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS pages_au AFTER UPDATE ON pages BEGIN
+    INSERT INTO pages_fts(pages_fts, rowid, title, content, language) VALUES('delete', old.rowid, old.title, old.content, old.language);
+    INSERT INTO pages_fts(rowid, title, content, language) VALUES (new.rowid, new.title, new.content, new.language);
+  END;
 SQL
 
 db.execute_batch(schema)

--- a/ruby-app/init_pages.rb
+++ b/ruby-app/init_pages.rb
@@ -37,5 +37,8 @@ rows.each do |title, url, language, last_updated, content|
   )
 end
 
+db.execute("INSERT INTO pages_fts(pages_fts) VALUES('rebuild')")
+
 puts 'Cleared pages table'
+puts "Rebuilt FTS5 index"
 puts "Inserted #{rows.length} test pages into whoknows.db"


### PR DESCRIPTION
### What has changed?
Replaced the SQL LIKE operator with SQLite FTS5 for page searches.

### Why did it need to be changed?
LIKE does a full table scan which is slow on large datasets. FTS5 uses an inverted index for faster searches and adds relevance ranking.

### How did you change it?
Added FTS5 virtual table with sync triggers, updated the search query to use MATCH, and added documentation.

***

**Checklist**

- [x] Application compiles
- [x] Documentation added
