### PR TITLE
rack-session bumped from 2.1.1 → 2.1.2

### DIFF
--- a/ruby-app/Gemfile
+++ b/ruby-app/Gemfile
@@ -10,7 +10,7 @@ gem 'rackup'
 gem 'rswag-ui'
 gem 'rubocop', require: false
 gem 'pg'
-gem 'rack-session', '>= 2.1.2'
+gem 'rack-session', '~> 2.1.2'
 gem 'sequel'
 gem 'sinatra'
 gem 'tailwindcss'

--- a/ruby-app/Gemfile
+++ b/ruby-app/Gemfile
@@ -10,6 +10,7 @@ gem 'rackup'
 gem 'rswag-ui'
 gem 'rubocop', require: false
 gem 'pg'
+gem 'rack-session', '>= 2.1.2'
 gem 'sequel'
 gem 'sinatra'
 gem 'tailwindcss'

--- a/ruby-app/Gemfile.lock
+++ b/ruby-app/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)
@@ -207,6 +207,7 @@ DEPENDENCIES
   json
   pg
   puma
+  rack-session (>= 2.1.2)
   rack-test
   rackup
   rerun


### PR DESCRIPTION
### What has changed?

Pinned the rack-session version to 2.1.2 due to a CRITICAL vulnerability.

### Why did it need to be changed?

To protect the app from malicious activity.

### How did you change it?

I added
 ```ruby
gem 'rack-session', '>= 2.1.2'
```
to the Gemfile

***

**Checklist**

- [ ] Application compiles
- [ ] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Security & Dependency Management

**Positive:** This PR addresses a legitimate security vulnerability (CVE-2025-46336 in rack-session, which prevents `Rack::Session::Pool` from recreating deleted sessions). Patching dependencies promptly is a good DevOps practice, especially given the project's recent security incident documented in `documentation/incidents/security-breach.md`.

**Issues:**

1. **Missing vulnerability context:** The PR title and description mention a "CRITICAL vulnerability" but don't reference the specific CVE (CVE-2025-46336) or explain what threat it mitigates. Future maintainers won't understand why this bump was necessary. For a learning project focused on DevOps principles, include security details in PR descriptions.

2. **Version constraint is too loose:** The constraint `'>= 2.1.2'` allows any future version (2.2.0, 3.0.0, etc.), which could introduce breaking changes without your awareness. For security patches, consider using `'~> 2.1.2'` (allows patch updates only) or pinning to `'2.1.2'` explicitly.

3. **Incomplete pre-merge checklist:** The PR description shows unchecked boxes for "application compilation" and "documentation updates," yet the PR is marked ready. For a security fix, these should be verified and documented before merging. Document why no additional configuration or code changes are needed.

**Recommendation:** Add a commit comment or update the PR description to explain: (a) the specific vulnerability and its impact, (b) why the version constraint was chosen, and (c) confirmation that no application code changes are required to benefit from the patch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->