### PR TITLE
changed app to web

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -40,5 +40,5 @@ jobs:
           fi
 
           docker compose pull web
-          docker compose up -d --no-deps app
+          docker compose up -d --no-deps web
           EOF


### PR DESCRIPTION
### What has changed?
Changed service from app to web
### Why did it need to be changed?
Our service is called web not app
### How did you change it?
by changing the name
***

**Checklist**

- [ ] Application compiles
- [ ] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR corrects the deployment workflow to reference the actual service name defined in the docker-compose configuration. The change updates `.github/workflows/CD.yaml` to deploy the `web` service instead of a non-existent `app` service, aligning the CI/CD automation with the infrastructure definition in `ruby-app/compose.yaml`.

## What Changed

- Modified `.github/workflows/CD.yaml`: changed `docker compose up -d --no-deps app` to `docker compose up -d --no-deps web`
- Single atomic commit with focused scope

## Alignment with Actual Infrastructure

The `ruby-app/compose.yaml` file defines the service as `web`, not `app`. This change corrects a mismatch between the deployment script and infrastructure-as-code, ensuring the deployment automation actually targets the correct service.

## Observations

**Good:**
- Change is minimal and focused
- Fixes a real inconsistency between IaC and deployment automation
- Demonstrates awareness of the infrastructure definition

**Incomplete Items:**
Per the PR checklist, the following items remain uncompleted:
- Application compiles
- Documentation added

Consider completing these before merge and providing evidence in the PR comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->