### PR TITLE
Optimize search with PostgreSQL full-text search and relevance ranking

### DIFF
--- a/.github/workflows/rubocop.yaml
+++ b/.github/workflows/rubocop.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.3'
           bundler-cache: true
           working-directory: ruby-app
 

--- a/ruby-app/app.rb
+++ b/ruby-app/app.rb
@@ -599,13 +599,17 @@ get '/api/search' do
   dataset = dataset.where(language: language) unless language.empty?
     dataset = apply_search(dataset, query, language) unless query.empty?
   results = dataset.select(:title, :url, :language, :last_updated, :content).all
-  hit = results.empty? ? 'miss' : 'hit'
+  # Filter out any extra fields (e.g., rank_title, rank_fts) for API output
+  filtered_results = results.map { |row| row.slice(:title, :url, :language, :last_updated, :content) }
+  hit = filtered_results.empty? ? 'miss' : 'hit'
   duration = monotonic_now - started_at
 
+  # Ensure metrics use the correct path label for /api/search
+  env['sinatra.route'] = 'GET /api/search'
   SEARCH_QUERIES_TOTAL.increment(labels: { language: language_label_for(query), hit: hit })
   SEARCH_DURATION_SECONDS.observe(duration, labels: { language: language_label_for(query), hit: hit })
 
-  json results: results
+  json results: filtered_results
 end
 
 post '/api/login' do

--- a/ruby-app/app.rb
+++ b/ruby-app/app.rb
@@ -565,13 +565,15 @@ get '/api/search' do
     dataset = dataset.order(Sequel.desc(:rank_title), Sequel.desc(:rank_fts))
   end
   results = dataset.select(:title, :url, :language, :last_updated, :content).all
-  hit = results.empty? ? 'miss' : 'hit'
+  # Filter out any extra fields (e.g., rank_title, rank_fts) for API output
+  filtered_results = results.map { |row| row.slice(:title, :url, :language, :last_updated, :content) }
+  hit = filtered_results.empty? ? 'miss' : 'hit'
   duration = monotonic_now - started_at
 
   SEARCH_QUERIES_TOTAL.increment(labels: { language: language_label_for(query), hit: hit })
   SEARCH_DURATION_SECONDS.observe(duration, labels: { language: language_label_for(query), hit: hit })
 
-  json results: results
+  json results: filtered_results
 end
 
 post '/api/login' do

--- a/ruby-app/app.rb
+++ b/ruby-app/app.rb
@@ -160,7 +160,7 @@ def apply_search_filters(dataset, query, language)
   if DB.database_type == :postgres
     ts_query = Sequel.function(:plainto_tsquery, pg_language, query)
     rank_fts = Sequel.function(:ts_rank, :search_vector, ts_query)
-    dataset = dataset.where { search_vector.op('@@', ts_query) }
+    dataset = dataset.where(Sequel.lit('search_vector @@ ?', ts_query))
     dataset = dataset.select_append(rank_title.as(:rank_title), rank_fts.as(:rank_fts))
     dataset = dataset.order(Sequel.desc(rank_title), Sequel.desc(rank_fts))
   else
@@ -179,26 +179,6 @@ helpers do
   include Rack::Utils
   alias_method :h, :escape_html
 
-    # Helper for search logic with Postgres/SQLite fallback
-    def apply_search(dataset, query, language)
-      rank_title = Sequel.case({ true => 2 }, 0, Sequel.function(:lower, :title) => query.downcase)
-      if DB.database_type == :postgres
-        lang_map = { 'en' => 'english', 'da' => 'danish' }
-        pg_language = lang_map[language] || 'english'
-        ts_query = Sequel.function(:plainto_tsquery, pg_language, query)
-        rank_fts = Sequel.function(:ts_rank, :search_vector, ts_query)
-        dataset = dataset.where { search_vector.op('@@', ts_query) }
-        dataset = dataset.select_append(rank_title.as(:rank_title), rank_fts.as(:rank_fts))
-        dataset = dataset.order(Sequel.desc(rank_title), Sequel.desc(rank_fts))
-      else
-        like_query = "%#{query.downcase}%"
-        title_match = Sequel.function(:lower, :title).like(like_query)
-        content_match = Sequel.function(:lower, :content).like(like_query)
-        dataset = dataset.where(Sequel.|(title_match, content_match))
-        dataset = dataset.order(Sequel.desc(rank_title))
-      end
-      dataset
-    end
   def json(payload = nil, status_code: nil, **kwargs)
     response_payload = payload || kwargs
     content_type :json
@@ -420,10 +400,8 @@ get '/' do
     started_at = monotonic_now
     dataset = DB[:pages]
     dataset = dataset.where(language: language)
-      dataset = apply_search(dataset, query, language) unless query.to_s.strip.empty?
-    
+    dataset = apply_search_filters(dataset, query, language) unless query.to_s.strip.empty?
     results = dataset.select(:title, :url, :language, :last_updated, :content).all
-    
     hit = results.empty? ? 'miss' : 'hit'
     duration = monotonic_now - started_at
 
@@ -598,15 +576,11 @@ get '/api/search' do
 
   dataset = DB[:pages]
   dataset = dataset.where(language: language) unless language.empty?
-    dataset = apply_search(dataset, query, language) unless query.empty?
-  
+  dataset = apply_search_filters(dataset, query, language) unless query.empty?
   results = dataset.select(:title, :url, :language, :last_updated, :content).all
-  
   hit = results.empty? ? 'miss' : 'hit'
   duration = monotonic_now - started_at
 
-  # Ensure metrics use the correct path label for /api/search
-  env['sinatra.route'] = 'GET /api/search'
   SEARCH_QUERIES_TOTAL.increment(labels: { language: language_label_for(query), hit: hit })
   SEARCH_DURATION_SECONDS.observe(duration, labels: { language: language_label_for(query), hit: hit })
 

--- a/ruby-app/app.rb
+++ b/ruby-app/app.rb
@@ -189,14 +189,13 @@ helpers do
         rank_fts = Sequel.function(:ts_rank, :search_vector, ts_query)
         dataset = dataset.where { search_vector.op('@@', ts_query) }
         dataset = dataset.select_append(rank_title.as(:rank_title), rank_fts.as(:rank_fts))
-        dataset = dataset.order(Sequel.desc(:rank_title), Sequel.desc(:rank_fts))
+        dataset = dataset.order(Sequel.desc(rank_title), Sequel.desc(rank_fts))
       else
         like_query = "%#{query.downcase}%"
         title_match = Sequel.function(:lower, :title).like(like_query)
         content_match = Sequel.function(:lower, :content).like(like_query)
         dataset = dataset.where(Sequel.|(title_match, content_match))
-        dataset = dataset.select_append(rank_title.as(:rank_title))
-        dataset = dataset.order(Sequel.desc(:rank_title))
+        dataset = dataset.order(Sequel.desc(rank_title))
       end
       dataset
     end
@@ -422,7 +421,9 @@ get '/' do
     dataset = DB[:pages]
     dataset = dataset.where(language: language)
       dataset = apply_search(dataset, query, language) unless query.to_s.strip.empty?
+    
     results = dataset.select(:title, :url, :language, :last_updated, :content).all
+    
     hit = results.empty? ? 'miss' : 'hit'
     duration = monotonic_now - started_at
 
@@ -598,10 +599,10 @@ get '/api/search' do
   dataset = DB[:pages]
   dataset = dataset.where(language: language) unless language.empty?
     dataset = apply_search(dataset, query, language) unless query.empty?
+  
   results = dataset.select(:title, :url, :language, :last_updated, :content).all
-  # Filter out any extra fields (e.g., rank_title, rank_fts) for API output
-  filtered_results = results.map { |row| row.slice(:title, :url, :language, :last_updated, :content) }
-  hit = filtered_results.empty? ? 'miss' : 'hit'
+  
+  hit = results.empty? ? 'miss' : 'hit'
   duration = monotonic_now - started_at
 
   # Ensure metrics use the correct path label for /api/search
@@ -609,7 +610,7 @@ get '/api/search' do
   SEARCH_QUERIES_TOTAL.increment(labels: { language: language_label_for(query), hit: hit })
   SEARCH_DURATION_SECONDS.observe(duration, labels: { language: language_label_for(query), hit: hit })
 
-  json results: filtered_results
+  json results: results
 end
 
 post '/api/login' do

--- a/ruby-app/app.rb
+++ b/ruby-app/app.rb
@@ -371,7 +371,16 @@ get '/' do
     started_at = monotonic_now
     dataset = DB[:pages]
     dataset = dataset.where(language: language)
-    dataset = dataset.where(Sequel.ilike(:title, "%#{query}%") | Sequel.ilike(:content, "%#{query}%")) unless query.to_s.strip.empty?
+    unless query.to_s.strip.empty?
+      # Brug full-text search og prioriter eksakte matches
+      ts_query = Sequel.function(:plainto_tsquery, 'english', query)
+      # Rank: eksakt match på title > full-text match > ingen
+      rank_title = Sequel.case({true => 2}, 0, Sequel.function(:lower, :title) => query.downcase)
+      rank_fts = Sequel.function(:ts_rank, :search_vector, ts_query)
+      dataset = dataset.where{ search_vector.op('@@', ts_query) }
+      dataset = dataset.select_append(rank_title.as(:rank_title), rank_fts.as(:rank_fts))
+      dataset = dataset.order(Sequel.desc(:rank_title), Sequel.desc(:rank_fts))
+    end
     results = dataset.select(:title, :url, :language, :last_updated, :content).all
     hit = results.empty? ? 'miss' : 'hit'
     duration = monotonic_now - started_at
@@ -547,8 +556,15 @@ get '/api/search' do
 
   dataset = DB[:pages]
   dataset = dataset.where(language: language) unless language.empty?
+  unless query.empty?
+    ts_query = Sequel.function(:plainto_tsquery, 'english', query)
+    rank_title = Sequel.case({true => 2}, 0, Sequel.function(:lower, :title) => query.downcase)
+    rank_fts = Sequel.function(:ts_rank, :search_vector, ts_query)
+    dataset = dataset.where{ search_vector.op('@@', ts_query) }
+    dataset = dataset.select_append(rank_title.as(:rank_title), rank_fts.as(:rank_fts))
+    dataset = dataset.order(Sequel.desc(:rank_title), Sequel.desc(:rank_fts))
+  end
   results = dataset.select(:title, :url, :language, :last_updated, :content).all
-  results = results.select { |row| row[:title].to_s.include?(query) } unless query.empty?
   hit = results.empty? ? 'miss' : 'hit'
   duration = monotonic_now - started_at
 

--- a/ruby-app/app.rb
+++ b/ruby-app/app.rb
@@ -146,10 +146,60 @@ def validate_registration_fields(payload)
   nil
 end
 
+# FIX 3: Extracted shared search logic into a helper to avoid duplication
+# between the HTML route (GET /) and the API route (GET /api/search).
+# FIX 1: Added Postgres/SQLite fallback so tests running against SQLite don't crash.
+# FIX 2: ORDER BY uses expressions directly instead of aliases, so the order
+#         is not lost when .select() later drops the appended rank columns.
+def apply_search_filters(dataset, query, language)
+  lang_map = { 'en' => 'english', 'da' => 'danish' }
+  pg_language = lang_map[language] || 'english'
+
+  rank_title = Sequel.case({ true => 2 }, 0, Sequel.function(:lower, :title) => query.downcase)
+
+  if DB.database_type == :postgres
+    ts_query = Sequel.function(:plainto_tsquery, pg_language, query)
+    rank_fts = Sequel.function(:ts_rank, :search_vector, ts_query)
+    dataset = dataset.where { search_vector.op('@@', ts_query) }
+    dataset = dataset.select_append(rank_title.as(:rank_title), rank_fts.as(:rank_fts))
+    dataset = dataset.order(Sequel.desc(rank_title), Sequel.desc(rank_fts))
+  else
+    like_query = "%#{query.downcase}%"
+    title_match = Sequel.function(:lower, :title).like(like_query)
+    content_match = Sequel.function(:lower, :content).like(like_query)
+    dataset = dataset.where(Sequel.|(title_match, content_match))
+    dataset = dataset.select_append(rank_title.as(:rank_title))
+    dataset = dataset.order(Sequel.desc(rank_title))
+  end
+
+  dataset
+end
+
 helpers do
   include Rack::Utils
   alias_method :h, :escape_html
 
+    # Helper for search logic with Postgres/SQLite fallback
+    def apply_search(dataset, query, language)
+      rank_title = Sequel.case({ true => 2 }, 0, Sequel.function(:lower, :title) => query.downcase)
+      if DB.database_type == :postgres
+        lang_map = { 'en' => 'english', 'da' => 'danish' }
+        pg_language = lang_map[language] || 'english'
+        ts_query = Sequel.function(:plainto_tsquery, pg_language, query)
+        rank_fts = Sequel.function(:ts_rank, :search_vector, ts_query)
+        dataset = dataset.where { search_vector.op('@@', ts_query) }
+        dataset = dataset.select_append(rank_title.as(:rank_title), rank_fts.as(:rank_fts))
+        dataset = dataset.order(Sequel.desc(:rank_title), Sequel.desc(:rank_fts))
+      else
+        like_query = "%#{query.downcase}%"
+        title_match = Sequel.function(:lower, :title).like(like_query)
+        content_match = Sequel.function(:lower, :content).like(like_query)
+        dataset = dataset.where(Sequel.|(title_match, content_match))
+        dataset = dataset.select_append(rank_title.as(:rank_title))
+        dataset = dataset.order(Sequel.desc(:rank_title))
+      end
+      dataset
+    end
   def json(payload = nil, status_code: nil, **kwargs)
     response_payload = payload || kwargs
     content_type :json
@@ -371,16 +421,7 @@ get '/' do
     started_at = monotonic_now
     dataset = DB[:pages]
     dataset = dataset.where(language: language)
-    unless query.to_s.strip.empty?
-      # Brug full-text search og prioriter eksakte matches
-      ts_query = Sequel.function(:plainto_tsquery, 'english', query)
-      # Rank: eksakt match på title > full-text match > ingen
-      rank_title = Sequel.case({true => 2}, 0, Sequel.function(:lower, :title) => query.downcase)
-      rank_fts = Sequel.function(:ts_rank, :search_vector, ts_query)
-      dataset = dataset.where{ search_vector.op('@@', ts_query) }
-      dataset = dataset.select_append(rank_title.as(:rank_title), rank_fts.as(:rank_fts))
-      dataset = dataset.order(Sequel.desc(:rank_title), Sequel.desc(:rank_fts))
-    end
+      dataset = apply_search(dataset, query, language) unless query.to_s.strip.empty?
     results = dataset.select(:title, :url, :language, :last_updated, :content).all
     hit = results.empty? ? 'miss' : 'hit'
     duration = monotonic_now - started_at
@@ -556,24 +597,15 @@ get '/api/search' do
 
   dataset = DB[:pages]
   dataset = dataset.where(language: language) unless language.empty?
-  unless query.empty?
-    ts_query = Sequel.function(:plainto_tsquery, 'english', query)
-    rank_title = Sequel.case({true => 2}, 0, Sequel.function(:lower, :title) => query.downcase)
-    rank_fts = Sequel.function(:ts_rank, :search_vector, ts_query)
-    dataset = dataset.where{ search_vector.op('@@', ts_query) }
-    dataset = dataset.select_append(rank_title.as(:rank_title), rank_fts.as(:rank_fts))
-    dataset = dataset.order(Sequel.desc(:rank_title), Sequel.desc(:rank_fts))
-  end
+    dataset = apply_search(dataset, query, language) unless query.empty?
   results = dataset.select(:title, :url, :language, :last_updated, :content).all
-  # Filter out any extra fields (e.g., rank_title, rank_fts) for API output
-  filtered_results = results.map { |row| row.slice(:title, :url, :language, :last_updated, :content) }
-  hit = filtered_results.empty? ? 'miss' : 'hit'
+  hit = results.empty? ? 'miss' : 'hit'
   duration = monotonic_now - started_at
 
   SEARCH_QUERIES_TOTAL.increment(labels: { language: language_label_for(query), hit: hit })
   SEARCH_DURATION_SECONDS.observe(duration, labels: { language: language_label_for(query), hit: hit })
 
-  json results: filtered_results
+  json results: results
 end
 
 post '/api/login' do

--- a/ruby-app/spec/integration/metrics_spec.rb
+++ b/ruby-app/spec/integration/metrics_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Metrics endpoint and instrumentation' do
       before_body,
       'search_queries_total',
       language: 'latin',
-      hit: 'miss'
+      hit: 'hit'
     )
 
     get '/api/search', { query: 'test' }
@@ -62,7 +62,7 @@ RSpec.describe 'Metrics endpoint and instrumentation' do
       after_body,
       'search_queries_total',
       language: 'latin',
-      hit: 'miss'
+      hit: 'hit'
     )
 
     expect(after_value).to be > before_value

--- a/ruby-app/spec/spec_helper.rb
+++ b/ruby-app/spec/spec_helper.rb
@@ -13,6 +13,7 @@ ENV['RACK_ENV'] = 'test'
 # SQLite URL format - Sequel expects sqlite:// for relative paths
 # Use just the filename for relative path from where Sequel.connect is called
 ENV['DATABASE_URL'] = "sqlite://#{TEST_DB_FILE}"
+ENV['MONITORING_IP'] = '127.0.0.1'
 
 def setup_test_db
   # Remove existing database file

--- a/ruby-app/views/layout.erb
+++ b/ruby-app/views/layout.erb
@@ -15,9 +15,13 @@
         <a id="nav-logo" href="/" class="hover:text-zinc-600 dark:hover:text-zinc-400 transition-colors">¿Who Knows?</a>
       </h1>
       <div class="flex items-center gap-4 text-sm">
-        <% if session[:user_id] %>
-          <a id="nav-logout" href="/logout" class="text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200 transition-colors">Log out [<%= session[:username] %>]</a>
-        <% else %>
+<% if session[:user_id] %>
+  <form action="/logout" method="post" style="display:inline">
+    <button type="submit" id="nav-logout" class="text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200 transition-colors cursor-pointer bg-transparent border-0 p-0">
+      Log out [<%= session[:username] %>]
+    </button>
+  </form>
+<% else %>
           <a id="nav-login" href="/login" class="text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200 transition-colors">Log in</a>
           <a id="nav-register" href="/register" class="text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200 transition-colors">Register</a>
         <% end %>


### PR DESCRIPTION
### What has changed?
- Use tsvector and plainto_tsquery for all searches (HTML and API)
- Prioritize exact title matches over partial matches (e.g., 'java' before 'javascript')
- Sort results by relevance and exactness

### Why did it need to be changed?
- Greatly improves the search speed and result quality for the pages table
### How did you change it?
I updated the search logic in both the main page and API search routes. Now both use PostgreSQL full-text search with relevance ranking for better and faster results.
***

**Checklist**

- [ ] Application compiles
- [ ] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Search Optimization: PostgreSQL Full-Text Search Implementation (updated)

**Scope / What changed**
- Replaces Ruby-side substring search with PostgreSQL full-text search (plainto_tsquery / search_vector) for both HTML (GET /) and API (/api/search) routes.
- Adds relevance ranking (ts_rank) and explicit prioritization of exact title matches over partial matches (e.g., "java" before "javascript").
- Consolidates filtering into an apply_search_filters helper used by both routes.
- Adds SQLite fallback for tests; API now returns only expected fields (tests adjusted).
- Ordering-by-rank expression corrected (use expressions not aliases).
- Minor UI change: logout converted from GET link to POST form.
- CI: RuboCop workflow bumped Ruby to 3.3.
- Tests: metrics spec expectation adjusted; MONITORING_IP initialized in spec_helper.

**Repository state / atomicity (DevOps - Lean)**
- Repository shows 1 commit and 753 tracked files. A large vendor tree is present at ruby-app/vendor/ruby/... containing many gems. This is a strong sign vendor dependencies were committed into the repo and should be removed and gitignored.
- Action: split into atomic commits (minimum):
  1) Remove vendor files & update .gitignore
  2) Migration + DB changes (search_vector, trigger, indexes)
  3) App logic (apply_search_filters + API changes)
  4) Tests + CI updates + docs
- Rationale: committed vendor files bloat the repo, make history noisy, and violate the "Lean" principle.

Suggested git change to remove vendor from repo (apply as a single commit after verifying backups):
```suggestion
# .gitignore
ruby-app/vendor/
```

And to remove existing vendor files from history (example workflow):
```suggestion
git rm -r --cached ruby-app/vendor
git commit -m "Remove committed vendor gems; add to .gitignore"
```

**Security**
- Query construction uses Sequel DSL and postgres functions (plainto_tsquery/ts_rank) — risk of SQL injection appears low if query is passed as a bound parameter via Sequel functions. Confirm there are no string-interpolated SQL fragments elsewhere in the helper.
- The SQLite fallback uses ILIKE/LIKE filtering — make sure the fallback also uses bound parameters rather than string interpolation.
- No exposed secrets found in the brief output, but presence of large vendor files increases risk of accidental secrets being committed; audit vendor files for credentials before removing.

**Correctness / Edge cases / Tests (DevOps - Measurement & Automation)**
- Missing/untested edge cases to add:
  - Exact-match vs substring ordering: explicit tests for "java" vs "javascript".
  - Empty query (should return no results or a safe default).
  - Special characters, punctuation, and non-ASCII input (UTF-8 tokenization).
  - Language handling: code hardcodes 'english' to plainto_tsquery/to_tsvector while the app accepts a language parameter — this will mis-tokenize non-English pages. Tests should cover Danish and any other languages supported by the app.
  - Behavior with stopwords and short queries (e.g., "a", "the").
  - Fallback correctness: test that SQLite fallback returns consistent ordering and results compared to Postgres for common cases.
- Monitoring/metrics: metrics_spec was updated; ensure monitoring labels reflect real hit/miss semantics (Measurement).

Suggested test additions (RSpec style brief):
```suggestion
it "ranks exact title match higher than partial matches" do
  create(:page, title: "Java")
  create(:page, title: "JavaScript")
  get "/api/search?q=java"
  expect(json.first["title"]).to eq("Java")
end
```

**Code smells / maintainability (DevOps - Sharing & Culture)**
- apply_search_filters centralizes behavior — good for DRY, but ensure it remains small and testable. If it grows, split DB-specific logic (Postgres functions) into a DB-adapter layer and keep a thin interface for callers.
- Hardcoding Postgres language undermines internationalization; extract mapping from app language to pg language and centralize.
- The fallback path duplicates ranking logic (rank_title via LIKE); keep parity with Postgres behavior and document differences.

Suggested code change to pass language through to plainto_tsquery (GitHub suggestion format):
```suggestion
# app.rb (or helper)
# map application language to postgres config
LANG_MAP = { 'en' => 'english', 'da' => 'danish' }.freeze
pg_lang = LANG_MAP[language] || 'english'
ts_query = Sequel.function(:plainto_tsquery, pg_lang, query)
```

**Documentation**
- PR checklist shows "Application compiles" and "Documentation added" unchecked. Add short docs describing:
  - Migration details (search_vector trigger and index),
  - How to regenerate search_vector for existing rows,
  - Fallback behavior on SQLite and any expected differences.
- Add a note in README or docs/postgres-migration.md about supported languages and how to extend the LANG_MAP.

**Positive notes**
- Using DB full-text search improves speed and relevance (good for Measurement & Automation).
- Prioritizing exact title matches is user-focused and improves UX.
- Tests and CI were updated; presence of SQLite fallback makes tests portable.

If you want, I can:
- Produce a focused PR comment to request splitting the commit and removing vendor files.
- Produce the RSpec tests for the ranking and language cases to add to the suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->