### PR TITLE
add MkDocs Material documentation site with GitHub Pages deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,10 @@ on:
       - 'documentation/**'
       - 'mkdocs.yml'
 
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'documentation/**'
+      - 'mkdocs.yml'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - run: pip install mkdocs-material
+
+      - run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # WhoKnows Application - Multi-language Repository
 # Ruby + Python applications with shared patterns
 
+# === MkDocs ===
+site/
+
 # === Common Patterns ===
 # Environment and secrets
 .env

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,23 +9,22 @@ docs_dir: documentation
 theme:
   name: material
   palette:
-    - scheme: default
-      primary: indigo
-      accent: indigo
-      toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
-    - scheme: slate
-      primary: indigo
-      accent: indigo
-      toggle:
-        icon: material/brightness-4
-        name: Switch to light mode
+    scheme: slate
+    primary: black
+    accent: deep purple
+  font:
+    text: Inter
+    code: JetBrains Mono
   features:
     - navigation.sections
+    - navigation.instant
+    - navigation.tracking
     - navigation.top
+    - toc.follow
     - search.highlight
+    - search.suggest
     - content.action.edit
+    - content.code.copy
 
 nav:
   - Home: README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,62 @@
+site_name: WhoKnows Docs
+site_description: Internal documentation for the WhoKnows project
+repo_url: https://github.com/ripmarkus/whoknows_ripmarkus
+repo_name: ripmarkus/whoknows_ripmarkus
+edit_uri: edit/main/documentation/
+
+docs_dir: documentation
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - content.action.edit
+
+nav:
+  - Home: README.md
+  - Getting Started:
+      - Local Setup: development/init_pages and init_db.md
+      - Branching Strategy: development/branching-strategy.md
+      - Contributing: development/contributions.md
+  - Architecture:
+      - Dependency Graph: architecture/dependency-graph.md
+      - OpenAPI Contracts: architecture/open-api.md
+  - DevOps:
+      - CI/CD Pipeline: devops/ci-cd.md
+      - Docker: devops/docker.md
+      - DevOps Philosophy: devops/devops-and-us.md
+      - Code Review (CodeRabbit): devops/coderabbit-review.md
+  - Database:
+      - Postgres Migrations: database/postgres-migration.md
+  - Testing:
+      - Testing Overview: testing/testing.md
+      - Postman Monitoring: testing/postman-monitoring.md
+  - Runbooks & Incidents:
+      - Post-Mortem: incidents/post-mortem-shuresm57.md
+      - Python App Issues: incidents/problems-with-python-app.md
+      - Ruby App Issues: incidents/problems-with-ruby-app.md
+      - Security Breach: incidents/security-breach.md
+  - Ruby App:
+      - API Docs: ruby-documentation/api-docs.md
+      - Database Config: ruby-documentation/db-config.md
+      - Security: ruby-documentation/security-docs.md
+  - Reports:
+      - KPI Report: reports/KPI-report.md
+      - Mandatory 1: reports/mandatory-1/mandatory-1.md
+  - Reference:
+      - Useful Links: reference/useful-links.md

--- a/readme.md
+++ b/readme.md
@@ -33,3 +33,23 @@ When you've added a new feature, please add solid documentation on what you've m
 
 Add it to the issues tab!
 
+# Documentation Site (MkDocs)
+
+The `documentation/` folder is published as a static site via [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) and automatically deployed to GitHub Pages on every push to `main`.
+
+**Run locally:**
+
+```bash
+pip install mkdocs-material
+mkdocs serve          # live-reload preview at http://127.0.0.1:8000
+```
+
+**Add a new page:**
+
+1. Drop a `.md` file into the relevant subfolder under `documentation/`.
+2. Add an entry for it under the correct section in `mkdocs.yml` → `nav`.
+3. Push to `main` — GitHub Actions deploys automatically.
+
+**Deployment:** GitHub Pages at `https://ripmarkus.github.io/whoknows_ripmarkus/`
+(Enable Pages in repo Settings → Pages → Source: `gh-pages` branch.)
+


### PR DESCRIPTION
### What has changed?
Added MkDocs Material site config, a GitHub Actions deploy workflow, and local dev instructions.

### Why did it need to be changed?
The existing markdown docs had no published site. This makes them browsable via GitHub Pages.

### How did you change it?
- Added `mkdocs.yml` pointing at the existing `documentation/` folder with a full nav
- Added `.github/workflows/docs.yml` to deploy to the `gh-pages` branch on push to main
- Added `site/` to `.gitignore`
- Added local run and "how to add a page" instructions to `readme.md`

***

**Checklist**

- [ ] Application compiles
- [x] Documentation added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds MkDocs Material documentation site automation and deployment to GitHub Pages, aligning well with DevOps principles of **Automation** and **Sharing**. The changes enable automatic documentation deployment on every merge to main.

## What's Good

**Automation & Lean**: The GitHub Actions workflow is well-designed:
- Properly scoped path triggers (`documentation/**` and `mkdocs.yml`) avoid unnecessary runs
- Clean dependency installation with `mkdocs-material`
- Correct permission scoping with `contents: write`
- `fetch-depth: 0` enables potential git-based MkDocs features

**Sharing & Culture**: The extensive navigation structure in `mkdocs.yml` is excellent — it surfaces DevOps documentation (CI/CD, Docker, Code Review), runbooks, incident reports, and architecture decisions in an accessible, browsable format. This directly supports learning and knowledge sharing in a DevOps education context.

**Configuration**: The `.gitignore` update properly excludes the `site/` build directory, and README additions provide clear local setup instructions.

## Issues to Address

**Filename Convention**: The documentation file `development/init_pages and init_db.md` uses spaces in its filename. While MkDocs handles this, it's not a best practice for file paths (potential issues with scripts, tools, and consistency). Consider renaming to `init_pages_and_init_db.md` or `init-pages-and-init-db.md` and updating the `mkdocs.yml` reference accordingly.

**`mkdocs gh-deploy --force` Flag**: The `--force` flag overwrites the gh-pages branch without confirmation. This is acceptable here but worth documenting in CONTRIBUTING.md why force deployment is necessary (if there's a specific reason) or if it could be removed.

## Code Review Effort
Low — the configuration is straightforward and follows MkDocs Material conventions well.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->