### PR TITLE
Add search query logging

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -55,14 +55,14 @@ jobs:
         working-directory: ruby-app
         run: |
           docker compose up -d
-          for i in $(seq 1 15); do
+          for i in $(seq 1 10); do
             if curl -sf http://localhost:8080/; then
               echo "App is up!"
               break
             fi
             echo "Attempt $i failed, waiting..."
             sleep 3
-            if [ $i -eq 15 ]; then
+            if [ $i -eq 10 ]; then
               echo "App failed to start, printing logs..."
               docker compose logs web
               exit 1

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -56,7 +56,10 @@ jobs:
         run: |
           docker compose up -d
           for i in $(seq 1 15); do
-            curl -sf http://localhost:8080/ && echo "App is up!" && break
+            if curl -sf http://localhost:8080/; then
+              echo "App is up!"
+              break
+            fi
             echo "Attempt $i failed, waiting..."
             sleep 3
             if [ $i -eq 15 ]; then

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -55,8 +55,16 @@ jobs:
         working-directory: ruby-app
         run: |
           docker compose up -d
-          sleep 15
-          curl -f http://localhost:8080/
+          for i in $(seq 1 15); do
+            curl -sf http://localhost:8080/ && echo "App is up!" && break
+            echo "Attempt $i failed, waiting..."
+            sleep 3
+            if [ $i -eq 15 ]; then
+              echo "App failed to start, printing logs..."
+              docker compose logs web
+              exit 1
+            fi
+          done
           docker compose down
 
   docker_push:
@@ -67,23 +75,19 @@ jobs:
     permissions:
       contents: read
       packages: write
-
     steps:
       - uses: actions/checkout@v4
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/whoknows_ripmarkus
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,7 @@ dmypy.json
 # pytype static type analyzer
 .pytype/
 
+# logs
+
+logs/
+*.log

--- a/documentation/ruby-documentation/search-logging.md
+++ b/documentation/ruby-documentation/search-logging.md
@@ -1,0 +1,37 @@
+# Search Logging
+
+Search queries are logged to `logs/app.log` using Ruby's built-in `Logger`. This gives insight into what users are searching for, which informs what content to scrape and index.
+
+## Log format
+
+Each search — from both the HTML route (`GET /`) and the API route (`GET /api/search`) — produces a line like:
+
+```
+I, [2026-04-28T12:00:00] INFO -- : [SEARCH] query="docker" language="en" hit="hit" results=4
+```
+
+| Field | Description |
+|-------|-------------|
+| `query` | The raw search term entered by the user |
+| `language` | The language filter used (`en` or `da`) |
+| `hit` | Whether any results were returned (`hit` or `miss`) |
+| `results` | Number of results returned |
+
+## Where logs are stored
+
+Logs are written to `logs/app.log` inside the container, mounted to `ruby-app/logs/` on the host via Docker volume:
+
+```yaml
+volumes:
+  - ./logs:/app/logs
+```
+
+## Tailing logs in production
+
+```bash
+tail -f logs/app.log | grep '\[SEARCH\]'
+```
+
+## How this informs scraping
+
+The logged queries reveal what users actually search for. Those terms are used to decide which topics to scrape — see the scraper in `ruby-app/scraper/scraper.rb`.

--- a/ruby-app/Dockerfile
+++ b/ruby-app/Dockerfile
@@ -12,7 +12,6 @@ COPY Gemfile Gemfile.lock* ./
 RUN bundle install
 COPY . .
 
-
 # Download Tailwind CLI v4 (musl build for Alpine) and compile CSS
 RUN apk add --no-cache curl
 RUN curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/download/v4.2.4/tailwindcss-linux-x64-musl && \
@@ -34,7 +33,7 @@ WORKDIR /app
 COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build /app .
 
-RUN chown -R appuser:appuser /app
+RUN mkdir -p /app/logs && chown -R appuser:appuser /app
 USER appuser
 
 EXPOSE 8080

--- a/ruby-app/app.rb
+++ b/ruby-app/app.rb
@@ -7,6 +7,7 @@ require 'bcrypt'
 require 'net/http'
 require 'uri'
 require 'logger'
+require 'fileutils'
 require 'ipaddr'
 require 'dotenv/load'
 require 'prometheus/client'
@@ -17,7 +18,8 @@ configure do
   set :show_exceptions, false
   set :protection, except: :host_authorization
 
-  LOGGER = Logger.new($stdout)
+  FileUtils.mkdir_p('logs')
+  LOGGER = Logger.new('logs/app.log')
 
   Dir.chdir(__dir__) if ENV['RACK_ENV'] == 'test'
 
@@ -403,6 +405,7 @@ get '/' do
     dataset = apply_search_filters(dataset, query, language) unless query.to_s.strip.empty?
     results = dataset.select(:title, :url, :language, :last_updated, :content).all
     hit = results.empty? ? 'miss' : 'hit'
+    LOGGER.info("[SEARCH] query=#{query.to_s.strip.inspect} language=#{language.inspect} hit=#{hit} results=#{results.size}")
     duration = monotonic_now - started_at
 
     SEARCH_QUERIES_TOTAL.increment(labels: { language: language_label_for(query), hit: hit })
@@ -579,6 +582,7 @@ get '/api/search' do
   dataset = apply_search_filters(dataset, query, language) unless query.empty?
   results = dataset.select(:title, :url, :language, :last_updated, :content).all
   hit = results.empty? ? 'miss' : 'hit'
+  LOGGER.info("[SEARCH] query=#{query.inspect} language=#{language.inspect} hit=#{hit} results=#{results.size}")
   duration = monotonic_now - started_at
 
   SEARCH_QUERIES_TOTAL.increment(labels: { language: language_label_for(query), hit: hit })

--- a/ruby-app/app.rb
+++ b/ruby-app/app.rb
@@ -18,8 +18,9 @@ configure do
   set :show_exceptions, false
   set :protection, except: :host_authorization
 
-  FileUtils.mkdir_p('logs')
-  LOGGER = Logger.new('logs/app.log')
+  log_dir = File.join(__dir__, 'logs')
+  FileUtils.mkdir_p(log_dir)
+  LOGGER = Logger.new(File.join(log_dir, 'app.log'))
 
   Dir.chdir(__dir__) if ENV['RACK_ENV'] == 'test'
 

--- a/ruby-app/compose.yaml
+++ b/ruby-app/compose.yaml
@@ -24,6 +24,8 @@ services:
       DATABASE_URL: postgres://whoknows:secret@db:5432/whoknows_test
     ports:
       - "8080:8080"
+    volumes:
+      - ./logs:/app/logs
     depends_on:
       db:
         condition: service_healthy

--- a/ruby-app/compose.yaml
+++ b/ruby-app/compose.yaml
@@ -25,7 +25,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./logs:/app/logs
+      - app_logs:/app/logs
     depends_on:
       db:
         condition: service_healthy
@@ -37,3 +37,4 @@ services:
 
 volumes:
   postgres_data:
+  app_logs:


### PR DESCRIPTION
### What has changed?
Search queries are now logged to `logs/app.log` from both the HTML and API search routes.

### Why did it need to be changed?
To understand what users are searching for, so we can scrape and index relevant content.

### How did you change it?
Added `LOGGER.info` calls after each search, changed logger output from stdout to a file, mounted the log directory as a Docker volume, and added documentation.

***

**Checklist**

- [ ] Application compiles
- [x] Documentation added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Search Query Logging Implementation

### Overview
This PR adds search query logging to capture user searches for content scraping/indexing guidance. Logging is now written to a persistent file, Docker volume mounting enables log persistence, and documentation is included.

### Implementation verified
✓ Logger redirected to `logs/app.log` (line 22)  
✓ Directory created via `FileUtils.mkdir_p('logs')` (line 21)  
✓ Search logging in HTML route `GET /` (line 408)  
✓ Search logging in API route `GET /api/search` (line 585)  
✓ Docker volume mount in compose.yaml (line 28)  
✓ Documentation is accurate and complete

### Issues requiring attention

1. **No error handling for logger initialization**: If directory creation or logger instantiation fails, the application will crash at startup. Add error handling:
   ```ruby
   begin
     FileUtils.mkdir_p('logs')
     LOGGER = Logger.new('logs/app.log')
   rescue => e
     warn("Failed to initialize logger: #{e.message}. Logging to STDOUT instead.")
     LOGGER = Logger.new($stdout)
   end
   ```

2. **Missing log rotation configuration**: Without rotation, `logs/app.log` will grow unbounded in production. Add rotation policy:
   ```ruby
   LOGGER = Logger.new('logs/app.log', shift_age: 'daily')  # or shift_size: '10485760' for 10MB
   ```
   Document expected log cleanup/archival strategy.

3. **Docker volume ownership concern**: The compose.yaml mounts `./logs:/app/logs`. If the `logs/` directory doesn't exist on the host:
   - Docker creates it as root
   - This can cause permission issues when the container process writes logs
   
   Either:
   - Document the prerequisite: `mkdir -p ruby-app/logs` before starting containers
   - Or add initialization logic to handle permission errors gracefully (ties to issue #1)

4. **Minor: Query handling inconsistency**: The two routes handle query formatting slightly differently:
   - HTML route: `query.to_s.strip.inspect` (line 408)
   - API route: `query.inspect` (line 585)
   
   This is functional but inconsistent. Consider normalizing both to use the same approach for consistency in parsed logs.

### Code quality observations
- Good use of the Measurement principle: structured `[SEARCH]` tags make logs machine-parseable
- Clean separation: logging added to existing routes without architectural changes
- Metrics (`SEARCH_QUERIES_TOTAL`, `SEARCH_DURATION_SECONDS`) complement the logs well

### Pre-merge checklist
- [ ] Application starts successfully even if `logs/` directory cannot be created
- [ ] Verify log rotation is configured or document rotation strategy
- [ ] Test with restricted filesystem permissions
- [ ] Confirm both routes log with consistent format
- [ ] Update `.gitignore` to exclude `logs/app.log` if not already present

<!-- end of auto-generated comment: release notes by coderabbit.ai -->