### PR TITLE
fixed CD, so when backup fails (independantly), it doesnt stop the pi…

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -21,21 +21,25 @@ jobs:
 
       - name: Deploy app
         run: |
-          ssh -i ~/.ssh/homeserver -o StrictHostKeyChecking=no "${{ secrets.SERVER_USER }}@${{ secrets.SERVER_IP }}" <<'EOF'
-          set -ux
+          ssh -i ~/.ssh/homeserver -o StrictHostKeyChecking=no "${{ secrets.SERVER_USER }}@${{ secrets.SERVER_IP }}" 'bash -s' <<'EOF'
+          set -euo pipefail
 
+          echo "Logging in to GHCR..."
           echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USERNAME }}" --password-stdin
 
+          echo "Changing to app directory..."
           cd /opt/docker/devops/whoknows_ripmarkus/ruby-app
+
+          echo "Starting optional pre-deploy backup..."
 
           BACKUP_DIR="/opt/backups/whoknows"
           TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+          BACKUP_FILE="$BACKUP_DIR/pre_deploy_${TIMESTAMP}.dump"
+
           mkdir -p "$BACKUP_DIR"
 
-          echo "Starting optional backup..."
-
           if docker compose ps --services --status running | grep -q '^db$'; then
-            BACKUP_FILE="$BACKUP_DIR/pre_deploy_${TIMESTAMP}.dump"
+            echo "Database container is running. Creating backup..."
 
             if docker compose exec -T db pg_dump -U whoknows --format=custom whoknows > "$BACKUP_FILE"; then
               echo "Backup created: $BACKUP_FILE"
@@ -43,17 +47,18 @@ jobs:
               echo "Cleaning old backups..."
               ls -t "$BACKUP_DIR"/*.dump 2>/dev/null | tail -n +11 | xargs -r rm -f || true
             else
-              echo "WARNING: Backup failed, continuing deployment anyway"
+              rm -f "$BACKUP_FILE"
+              echo "WARNING: Backup failed. Continuing deployment anyway."
             fi
           else
-            echo "db is not running, skipping backup"
+            echo "WARNING: Database container is not running. Skipping backup."
           fi
 
-          echo "Pulling new web image..."
+          echo "Pulling latest web image..."
           docker compose pull web
 
           echo "Restarting web container..."
           docker compose up -d --no-deps web
 
-          echo "Deployment done"
+          echo "Deployment done."
           EOF

--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Deploy app
         run: |
           ssh -i ~/.ssh/homeserver -o StrictHostKeyChecking=no "${{ secrets.SERVER_USER }}@${{ secrets.SERVER_IP }}" <<'EOF'
-          set -eux
+          set -ux
 
           echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USERNAME }}" --password-stdin
 
@@ -32,13 +32,28 @@ jobs:
           TIMESTAMP=$(date +%Y%m%d_%H%M%S)
           mkdir -p "$BACKUP_DIR"
 
+          echo "Starting optional backup..."
+
           if docker compose ps --services --status running | grep -q '^db$'; then
-            docker compose exec -T db pg_dump -U whoknows --format=custom whoknows > "$BACKUP_DIR/pre_deploy_${TIMESTAMP}.dump"
-            ls -t "$BACKUP_DIR"/*.dump | tail -n +11 | xargs -r rm
+            BACKUP_FILE="$BACKUP_DIR/pre_deploy_${TIMESTAMP}.dump"
+
+            if docker compose exec -T db pg_dump -U whoknows --format=custom whoknows > "$BACKUP_FILE"; then
+              echo "Backup created: $BACKUP_FILE"
+
+              echo "Cleaning old backups..."
+              ls -t "$BACKUP_DIR"/*.dump 2>/dev/null | tail -n +11 | xargs -r rm -f || true
+            else
+              echo "WARNING: Backup failed, continuing deployment anyway"
+            fi
           else
             echo "db is not running, skipping backup"
           fi
 
+          echo "Pulling new web image..."
           docker compose pull web
+
+          echo "Restarting web container..."
           docker compose up -d --no-deps web
+
+          echo "Deployment done"
           EOF


### PR DESCRIPTION
…peline
### What has changed?
The cd pipeline is a little more robust now, since the last yaml, version often wasnt deploying properly.
### Why did it need to be changed?
Bad deployment
### How did you change it?
changed the cd.yaml file.
***

**Checklist**

- [ ] Application compiles
- [ ] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR improves CD pipeline resilience by preventing backup failures from blocking deployments. The change restructures the pre-deploy database backup to fail gracefully rather than halting the entire pipeline.

## Changes Made

**`.github/workflows/CD.yaml`**

The deployment script was modified to:
- Change shell options from `set -eux` to `set -ux` (removes automatic exit on error)
- Add a runtime check to skip backup if the database container isn't running
- Wrap the `pg_dump` command in a conditional block that catches failures
- Log backup completion and clean old backup files only on successful dumps
- Print a warning and continue deployment if backup fails
- Add explicit echo statements for observability at each deployment stage

## DevOps Assessment

**Strengths:**
- **Resilience**: Correctly prioritizes deployment success over backup completion. In DevOps, non-critical failures shouldn't block critical operations.
- **Observability**: Echo statements provide clear deployment flow logging, supporting the "Measurement & Sharing" principle.
- **Safety**: Pre-deployment DB health check (checking if container is running) prevents unnecessary backup attempts.
- **Graceful degradation**: Uses `xargs -r` to safely handle empty file lists and `|| true` to suppress cleanup errors.

**Concerns & Recommendations:**

1. **Broad error suppression**: Removing `set -e` means subsequent deployment steps (docker pull, compose up) won't automatically fail on errors. Verify that the docker commands after the backup section can fail safely. Consider adding explicit error checks for critical operations if they follow this backup logic.

2. **Missing context**: The raw summary mentions "bad deployment" issues previously, but without seeing the prior version or test coverage, it's unclear if this fully resolves the problem or if additional error handling is needed for the docker operations.

3. **Documentation**: Add an inline comment explaining why backup failures don't stop deployment (e.g., "Backup is non-critical; deployment proceeds regardless of backup status").

## Questions for Code Review

- Are there subsequent deployment steps in the full script that could fail silently with `set -ux` instead of `set -eux`?
- Is there monitoring/alerting for backup failures so the team knows when backups aren't working?

<!-- end of auto-generated comment: release notes by coderabbit.ai -->