### PR TITLE
added a guide for local setup

### DIFF
--- a/documentation/local/setup-guide.md
+++ b/documentation/local/setup-guide.md
@@ -22,7 +22,7 @@ local   replication     all                                     trust
 host    replication     all             127.0.0.1/32            trust
 host    replication     all             ::1/128                 trust
 ```
-In here you want to replace the method 'sha-bla-bla' to trust..
+In here you want to replace the method 'scram-sha-256' to trust..
 This disables passwords on your local psql service - which is perfect, since the point is not exposing the db..
 After this, you will have to restart the service. Open up powershell with administrator privileges and run:
 ```bash
@@ -30,7 +30,7 @@ restart-Service postgresql-x64-18
 ```
 You will also have to add this directory: 'C:\Program Files\PostgreSQL\18\bin' to your path, for easier use..
 
-It is also important to note, that when you install postgres with winget the default user is 'postgres' and by changing your method from 'sha' to trust, you are basically disabling password auth for postgres..
+It is also important to note, that when you install postgres with winget the default user is 'postgres' and by changing your method from 'scram-sha-256' to trust, you are basically disabling password auth for postgres..
 
 When this step is complete, you will have to create a new database...
 ```bash

--- a/documentation/local/setup-guide.md
+++ b/documentation/local/setup-guide.md
@@ -1,18 +1,43 @@
-# Prerequisites
+# whoknows — Developer Setup Guide
+> Windows · PostgreSQL 18 · Ruby
+
+---
+
+## Step 1 — Install Ruby Dependencies
+
+Navigate into the project folder and install all gems:
+
 ```bash
 cd ruby-app
 bundle install
+
+# Install and build Tailwind CSS
+gem install tailwindcss-ruby
 bundle exec tailwindcss -i public/input.css -o public/output.css
 ```
 
-You will also need to download and install postgres..
-Windows:
+> **Note:** If the Tailwind commands fail, skip them for now and return to this step later.
+
+---
+
+## Step 2 — Install PostgreSQL 18
+
 ```bash
 winget install PostgreSQL.PostgreSQL.18
 ```
-Once this step is complete, you will want to edit your pg_hba.conf file...
-It is often on windows located here: C:\Program Files\PostgreSQL\18\data\pg_hba.conf
-Open your editor:
+
+---
+
+## Step 3 — Configure `pg_hba.conf`
+
+Open the config file in your editor. On Windows it is typically located at:
+
+```
+C:\Program Files\PostgreSQL\18\data\pg_hba.conf
+```
+
+Find every entry where the `METHOD` column reads `scram-sha-256` and change it to `trust`. The finished file should look like this:
+
 ```conf
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 local   all             all                                     trust
@@ -22,36 +47,64 @@ local   replication     all                                     trust
 host    replication     all             127.0.0.1/32            trust
 host    replication     all             ::1/128                 trust
 ```
-In here you want to replace the method 'scram-sha-256' to trust..
-This disables passwords on your local psql service - which is perfect, since the point is not exposing the db..
-After this, you will have to restart the service. Open up powershell with administrator privileges and run:
-```bash
-restart-Service postgresql-x64-18
+
+> ⚠️ **Security note:** Setting the method to `trust` disables password authentication for the local PostgreSQL service. This is intentional for local development — never do this on a publicly accessible server.
+
+---
+
+## Step 4 — Restart the PostgreSQL Service
+
+Open PowerShell **as Administrator** and run:
+
+```powershell
+Restart-Service postgresql-x64-18
 ```
-You will also have to add this directory: 'C:\Program Files\PostgreSQL\18\bin' to your path, for easier use..
 
-It is also important to note, that when you install postgres with winget the default user is 'postgres' and by changing your method from 'scram-sha-256' to trust, you are basically disabling password auth for postgres..
+Also add the PostgreSQL bin directory to your `PATH` so commands like `createdb` are available everywhere:
 
-When this step is complete, you will have to create a new database...
+```
+C:\Program Files\PostgreSQL\18\bin
+```
+
+---
+
+## Step 5 — Create the Database
+
+The default user created by the winget installer is `postgres`. Create the application database:
+
 ```bash
 createdb -U postgres whoknows
 ```
 
-After this you will have to replace your newly created and empty db with your dump... 
+---
+
+## Step 6 — Restore the Database Dump
+
+Replace the empty database with the provided SQL dump:
+
 ```bash
 psql -h 127.0.0.1 -U postgres -d whoknows -f .\full_dump.sql
 ```
-This line opens a connection to your already running postgress db, with the username postgres, database name whoknows, and at last the path to your SQL dump..
 
+This connects to your running PostgreSQL instance and imports the full schema and data from the dump file.
 
+---
 
-Once you're here you will want to change your environmental variables.. The variables are automatically loaded into the ruby program, once it starts..
+## Step 7 — Configure Environment Variables
+
+Look for the '.env' file in the root of the `ruby-app` directory. These variables are automatically loaded when the application starts:
+
 ```env
-OPENWEATHER_API_KEY=set
-POSTGRES_DB=set
-POSTGRES_USER=set
-POSTGRES_PASSWORD=set
+OPENWEATHER_API_KEY=<your_key>
+POSTGRES_DB=whoknows
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=
 DATABASE_URL=postgres://postgres@localhost:5432/whoknows
-MONITORING_IP=set
+MONITORING_IP=<your_ip>
 ```
 
+> **Tip:** `DATABASE_URL` is the most important variable. Check the application code if you are unsure which of the others are required.
+
+---
+
+**You're all set!** Start the application and verify everything is working.

--- a/documentation/local/setup-guide.md
+++ b/documentation/local/setup-guide.md
@@ -16,6 +16,8 @@ gem install tailwindcss-ruby
 bundle exec tailwindcss -i public/input.css -o public/output.css
 ```
 
+> **Note:** This project uses Tailwind CSS v4 syntax in `public/input.css` (`@import "tailwindcss"`). If the build fails with `Failed to find 'tailwindcss'`, your local bundle is still on Tailwind 3.x. Update the gem to `tailwindcss-ruby ~> 4.0`, run `bundle update tailwindcss-ruby`, and then rerun the build command above.
+
 > **Note:** If the Tailwind commands fail, skip them for now and return to this step later.
 
 ---

--- a/documentation/local/setup-guide.md
+++ b/documentation/local/setup-guide.md
@@ -1,0 +1,57 @@
+# Prerequisites
+```bash
+cd ruby-app
+bundle install
+bundle exec tailwindcss -i public/input.css -o public/output.css
+```
+
+You will also need to download and install postgres..
+Windows:
+```bash
+winget install PostgreSQL.PostgreSQL.18
+```
+Once this step is complete, you will want to edit your pg_hba.conf file...
+It is often on windows located here: C:\Program Files\PostgreSQL\18\data\pg_hba.conf
+Open your editor:
+```conf
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+local   all             all                                     trust
+host    all             all             127.0.0.1/32            trust
+host    all             all             ::1/128                 trust
+local   replication     all                                     trust
+host    replication     all             127.0.0.1/32            trust
+host    replication     all             ::1/128                 trust
+```
+In here you want to replace the method 'sha-bla-bla' to trust..
+This disables passwords on your local psql service - which is perfect, since the point is not exposing the db..
+After this, you will have to restart the service. Open up powershell with administrator privileges and run:
+```bash
+restart-Service postgresql-x64-18
+```
+You will also have to add this directory: 'C:\Program Files\PostgreSQL\18\bin' to your path, for easier use..
+
+It is also important to note, that when you install postgres with winget the default user is 'postgres' and by changing your method from 'sha' to trust, you are basically disabling password auth for postgres..
+
+When this step is complete, you will have to create a new database...
+```bash
+createdb -U postgres whoknows
+```
+
+After this you will have to replace your newly created and empty db with your dump... 
+```bash
+psql -h 127.0.0.1 -U postgres -d whoknows -f .\full_dump.sql
+```
+This line opens a connection to your already running postgress db, with the username postgres, database name whoknows, and at last the path to your SQL dump..
+
+
+
+Once you're here you will want to change your environmental variables.. The variables are automatically loaded into the ruby program, once it starts..
+```env
+OPENWEATHER_API_KEY=set
+POSTGRES_DB=set
+POSTGRES_USER=set
+POSTGRES_PASSWORD=set
+DATABASE_URL=postgres://postgres@localhost:5432/whoknows
+MONITORING_IP=set
+```
+

--- a/ruby-app/Gemfile
+++ b/ruby-app/Gemfile
@@ -14,7 +14,7 @@ gem 'pg'
 gem 'rack-session', '~> 2.1.2'
 gem 'sequel'
 gem 'sinatra'
-gem 'tailwindcss'
+gem "tailwindcss-ruby", "~> 4.0"
 gem 'prometheus-client'
 gem "activesupport", ">= 8.1.2.1"
 gem "loofah", ">= 2.25.1"

--- a/ruby-app/Gemfile.lock
+++ b/ruby-app/Gemfile.lock
@@ -183,7 +183,9 @@ GEM
     sqlite3 (2.9.3-x64-mingw-ucrt)
     sqlite3 (2.9.3-x86_64-linux-gnu)
     stringio (3.2.0)
-    tailwindcss (0.1.1)
+    tailwindcss-ruby (4.2.4-arm64-darwin)
+    tailwindcss-ruby (4.2.4-x64-mingw-ucrt)
+    tailwindcss-ruby (4.2.4-x86_64-linux-gnu)
     thor (1.5.0)
     tilt (2.7.0)
     tsort (0.2.0)
@@ -223,7 +225,7 @@ DEPENDENCIES
   sequel
   sinatra
   sqlite3
-  tailwindcss
+  tailwindcss-ruby (~> 4.0)
 
 BUNDLED WITH
    2.4.20


### PR DESCRIPTION
### What has changed?
Added a new directory in documentation called local, with a guide for a local setup..
### Why did it need to be changed?
there is no comprehensive guide for this yet, and it can be confusing..
### How did you change it?
added a new markdown file with a guide..
***

**Checklist**

- [ ] Application compiles
- [ ] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Security Concerns

**PostgreSQL Authentication Weakness**: The guide explicitly disables password authentication by changing `pg_hba.conf` method to `trust` with the rationale "which is perfect, since the point is not exposing the db." This reasoning is backwards—`trust` authentication actually removes password protection, allowing any local process to connect without credentials. This is a significant security risk even for local development:
- Any malicious process on the machine gains database access
- This trains developers in insecure practices they may replicate elsewhere
- The comment suggests a misunderstanding of what `trust` does

**Recommendation**: For local development, keep password authentication enabled (use `md5` or `scram-sha-256`). Document the credentials clearly in `.env.local` or similar, and document them in `.gitignore`. This maintains security practices alignment.

## Documentation Issues

**Incomplete Cross-Platform Coverage**: Instructions only cover Windows. The guide should include setup steps for Linux and macOS (different PostgreSQL paths, service restart commands, PATH configuration).

**Unclear Environment Variables**: The `OPENWEATHER_API_KEY`, `MONITORING_IP`, and other "set" placeholders need explanation—what should developers actually set these to? Where do they come from?

**Missing Context**: 
- Where does `full_dump.sql` come from and how should developers obtain it?
- What Ruby version is required? (mentioned in checklist)
- After setup, how do developers run the application?

**Informal Tone**: While approachable, phrases like "sha-bla-bla" reduce clarity and professionalism in documentation.

## DevOps Principles Alignment

**Positive**: This documentation advances the *Sharing* and *Culture* principles by reducing onboarding friction and reducing tribal knowledge.

**Gap**: The setup guide lacks *Automation*—consider adding a setup script (`.sh` or PowerShell) that automates these steps and reduces manual error. This aligns with DevOps practices of reproducible, documented automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->