### PR TITLE
Fix image paths in documentation for MkDocs rendering

### DIFF
--- a/documentation/architecture/dependency-graph.md
+++ b/documentation/architecture/dependency-graph.md
@@ -16,4 +16,4 @@ On top of this, it introduces technical debt by forcing us to learn a toolchain 
 
 It adds unnecessary overhead and doesn't provide us with clear functional value, time we'd rather spend on properly converting from Python2 to Ruby and making sure our new codebase is at its best.
 
-![dependencygraph](./imgs/dependency-graph.png)
+![dependencygraph](../imgs/dependency-graph.png)

--- a/documentation/architecture/open-api.md
+++ b/documentation/architecture/open-api.md
@@ -5,7 +5,7 @@ We want all developers to have a clear overview of our API and page endpoints, s
 
 The route /api/docs is an on premise Swagger/OpenAPI UI. The purpose it serves is to interact with the API directly from our browsers, and to test all of our endpoints.
 
-![OpenAPI](./imgs/OpenAPIpage.png)
+![OpenAPI](../imgs/OpenAPIpage.png)
 
 
 ## HTML Routes

--- a/documentation/development/contributions.md
+++ b/documentation/development/contributions.md
@@ -60,7 +60,7 @@ When you are done with the issue at hand, push the changes, go to the repository
 
 1. Compare & pull request
 
-![alt text](/documentation/imgs/2026-02-05_20-02.png)
+![alt text](../imgs/2026-02-05_20-02.png)
 
 The following is extremely important, so follow the numbered list with numbers on the image closely:
 
@@ -69,7 +69,7 @@ The following is extremely important, so follow the numbered list with numbers o
 ## 3. Base = main
 ## 4. Base repository = ripmarkus/whoknows_ripmarkus
 
-![alt text](/documentation/imgs/2026-02-05_20-06.png)
+![alt text](../imgs/2026-02-05_20-06.png)
 
 **Please use the PR template when submitting pull requests. This helps maintain consistency and keeps PRs clear and concise. Thank you!**
 
@@ -89,7 +89,7 @@ Select review.
 2. Select Comment, Approve or Request Changes.
 3. Submit Review
 
-![alt text](/documentation/imgs/2026-02-05_20-41.png)
+![alt text](../imgs/2026-02-05_20-41.png)
 
 After merging, delete the feature branch to keep the repository clean.
 

--- a/documentation/reports/mandatory-1/mandatory-1.md
+++ b/documentation/reports/mandatory-1/mandatory-1.md
@@ -62,7 +62,7 @@ On top of this, it introduces technical debt by forcing us to learn a toolchain 
 
 It adds unnecessary overhead and doesn't provide us with clear functional value, time we'd rather spend on properly converting from Python2 to Ruby and making sure our new codebase is at its best.
 
-![dependencygraph](../imgs/dependency-graph.png)
+![dependencygraph](../../imgs/dependency-graph.png)
 
 # Problems With Legacy Codebase
 
@@ -134,7 +134,7 @@ We want all developers to have a clear overview of our API and page endpoints, s
 The route /api/docs is an on premise Swagger/OpenAPI UI. The purpose it serves is to interact with the API directly from our browsers, and to test all of our endpoints.
 
 
-![OpenAPI](../imgs/OpenAPIpage.png)
+![OpenAPI](../../imgs/OpenAPIpage.png)
 ## Generation
 The OpenAPI specification was generated using Postman. All of our routes were added to a Postman collection. Examples were also added for almost every possible endpoint. The OpenAPI specification was generated shortly after this, using the `Generate Specification` feature. 
 

--- a/documentation/reports/mandatory-2/mandatory-2.md
+++ b/documentation/reports/mandatory-2/mandatory-2.md
@@ -106,7 +106,7 @@ For example, CodeRabbit pointed out that our logout link was incorrect. The fron
 
 This would have caused a 404 error when users tried to log out, so we fixed it by updating the link to match the correct endpoint. This is a good example of how the tool helped catch an issue that directly affects the user experience.
 
-![CodeRabbit-example](/documentation/imgs/2026-05-05_21-25.png)
+![CodeRabbit-example](../../imgs/2026-05-05_21-25.png)
 
 ## Which ones did you ignore?
 
@@ -114,7 +114,7 @@ We also ignored some minor suggestions from CodeRabbit that were related to word
 
 For example, CodeRabbit suggested fixing a double space and slightly awkward phrasing in a comment/text. While the suggestion was valid, it did not affect functionality or maintainability, so we chose not to prioritize it.
 
-![CodeRabbit-example](/documentation/imgs/2026-05-05_21-40.png)
+![CodeRabbit-example](../../imgs/2026-05-05_21-40.png)
 
 ## Why?
 

--- a/documentation/testing/postman-monitoring.md
+++ b/documentation/testing/postman-monitoring.md
@@ -57,12 +57,12 @@ To avoid repeating the domain in every request, we use a **collection variable**
 
 This makes it easy to change the deployment URL without modifying every endpoint.
 
-![Base URL variable configuration](/documentation/imgs/2026-03-10_18-10.png)
+![Base URL variable configuration](../imgs/2026-03-10_18-10.png)
 
 Requests are then written like this using the variable:
 
-![Example request using BASE_URL](/documentation/imgs/2026-04-29_09-04.png)
-![Example request using BASE_URL](/documentation/imgs/2026-03-10_18-17.png)
+![Example request using BASE_URL](../imgs/2026-04-29_09-04.png)
+![Example request using BASE_URL](../imgs/2026-03-10_18-17.png)
 
 ---
 
@@ -72,4 +72,4 @@ All endpoints in our monitoring collection use a shared test to verify that the 
 
 This test runs for every request in the collection and ensures that the application remains responsive.
 
-![Shared tests example](/documentation/imgs/2026-04-29_09-07.png)
+![Shared tests example](../imgs/2026-04-29_09-07.png)


### PR DESCRIPTION
### What has changed?

Fixed all broken image paths across 6 markdown files in the documentation to use correct relative paths that MkDocs can resolve.

### Why did it need to be changed?

Images are stored in `documentation/imgs/` but were referenced using incorrect paths:
- Three different broken patterns were in use
- Images were not rendering in the MkDocs site
- Path resolution failed because they didn't account for the `docs_dir` setting in mkdocs.yml

### How did you change it?

- Architecture docs (2 files): Changed `./imgs/` to `../imgs/`
- Development & testing docs (2 files): Changed `/documentation/imgs/` to `../imgs/`
- Reports docs (1 file): Changed `/documentation/imgs/` to `../../imgs/`

***

**Checklist**

- [x] Application compiles
- [x] Documentation added