### PR TITLE
feat: add keyword search metric and monitoring dashboards

### DIFF
--- a/documentation/devops/monitoring.md
+++ b/documentation/devops/monitoring.md
@@ -1,0 +1,72 @@
+# Monitoring
+
+We run a Prometheus and Grafana stack to track how the application behaves in production. Prometheus scrapes metrics from the app every 15 seconds and stores them. Grafana reads from Prometheus and visualizes the data in dashboards.
+
+## Stack Overview
+
+Prometheus runs on the app server and pulls metrics from:
+
+- Our Sinatra app at `/metrics` (exposed on port 8080, restricted to `MONITORING_IP`)
+- node_exporter for host-level CPU, memory, disk, network metrics
+
+Grafana runs in Docker on a separate monitoring server, accessing Prometheus via internal network.
+
+Dashboards are provisioned via GitOps: JSON files in the monitoring repo are automatically loaded by Grafana within 30 seconds of a push to main. No UI edits are persisted. All dashboard changes go through git commits.
+
+## What We Monitor
+
+### Business Metrics
+
+The Business Observability dashboard shows how users interact with the product.
+
+Successful logins track user retention. Search hit rate (successful searches over total searches) tells us if the search feature is useful. Registration count shows growth. Total search volume shows engagement.
+
+The two keyword tables surface product intelligence: top searched terms show what users want, and top keywords with no results highlight content gaps where users look but find nothing.
+
+## Security Metrics
+
+The Security Observability dashboard monitors for potential attacks and auth failures.
+
+Failed logins spike during brute force attacks. HTTP 401 (Unauthorized) and 403 (Forbidden) responses indicate access control issues. Failed registration attempts may signal spam or automated attack scripts.
+
+The failed login rate panel includes thresholds to highlight unusual patterns. The total request rate baseline helps spot DDoS or scanning activity.
+
+## Metrics Reference
+
+All metrics live in the Prometheus registry exposed by the app at `/metrics`.
+
+Counters (cumulative counts):
+
+`login_attempts_total` with label `result` (success, failure)
+`registrations_total` with label `result` (success, failure)
+`password_changes_total` with label `result` (success, failure)
+`search_queries_total` with labels `hit` (hit, miss) and `language` (latin, non_latin, unknown)
+`search_keyword_total` with labels `keyword` (the search term, lowercased) and `hit` (hit, miss)
+`http_requests_total` with labels `method`, `path`, `status_code`
+`http_request_errors_total` with labels `method`, `path`, `error_class`
+`weather_api_requests_total` with labels `phase`, `status_code`
+`weather_api_errors_total` with labels `phase`, `error_class`
+
+Histograms (distributions):
+
+`http_request_duration_seconds` with labels `method`, `path`, `status_code`
+`search_duration_seconds` with labels `language`, `hit`
+`weather_api_duration_seconds` with labels `phase`, `status_code`
+
+## Search Keyword Metric
+
+The `search_keyword_total` counter is new and enables the business dashboard keyword tables.
+
+When a user searches for something, we increment this counter with the query term (lowercased and stripped) and whether results were found. Blank searches (homepage load with no query) are skipped.
+
+At this scale, cardinality is acceptable. If users conduct hundreds of unique searches daily, the metric label values stay manageable for Prometheus. If this changes, we can aggregate keywords or apply a top-k filter at scrape time.
+
+## Grafana Access
+
+Grafana runs at the monitoring endpoint with admin credentials in `.env`. All dashboards are read-only in the UI since they are file-provisioned. To modify a dashboard, edit the JSON in git and push to main.
+
+Dashboard UIDs are unique identifiers used in URLs: `business-observability` and `security-observability`.
+
+## Deployment
+
+Push changes to the monitoring repo main branch. The GitHub Actions workflow SSHes into the monitoring server, runs `git pull`, and restarts docker-compose. Grafana detects new JSON files within its 30-second poll interval and loads them automatically.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - DevOps:
       - CI/CD Pipeline: devops/ci-cd.md
       - Docker: devops/docker.md
+      - Monitoring: devops/monitoring.md
       - DevOps Philosophy: devops/devops-and-us.md
       - Code Review (CodeRabbit): devops/coderabbit-review.md
   - Database:

--- a/ruby-app/metrics/metrics.rb
+++ b/ruby-app/metrics/metrics.rb
@@ -73,8 +73,8 @@ SEARCH_DURATION_SECONDS = fetch_or_register_histogram(
 SEARCH_KEYWORD_TOTAL = fetch_or_register_counter(
   PROM_REGISTRY,
   :search_keyword_total,
-  docstring: 'Search queries broken down by keyword and hit/miss',
-  labels: %i[keyword hit]
+  docstring: 'Search queries broken down by hit/miss (keywords logged separately)',
+  labels: %i[hit]
 )
 
 WEATHER_API_REQUESTS_TOTAL = fetch_or_register_counter(

--- a/ruby-app/metrics/metrics.rb
+++ b/ruby-app/metrics/metrics.rb
@@ -70,6 +70,13 @@ SEARCH_DURATION_SECONDS = fetch_or_register_histogram(
   buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2]
 )
 
+SEARCH_KEYWORD_TOTAL = fetch_or_register_counter(
+  PROM_REGISTRY,
+  :search_keyword_total,
+  docstring: 'Search queries broken down by keyword and hit/miss',
+  labels: %i[keyword hit]
+)
+
 WEATHER_API_REQUESTS_TOTAL = fetch_or_register_counter(
   PROM_REGISTRY,
   :weather_api_requests_total,

--- a/ruby-app/routes/api_routes.rb
+++ b/ruby-app/routes/api_routes.rb
@@ -46,6 +46,7 @@ get '/api/search' do
 
   SEARCH_QUERIES_TOTAL.increment(labels: { language: language_label_for(query), hit: hit })
   SEARCH_DURATION_SECONDS.observe(duration, labels: { language: language_label_for(query), hit: hit })
+  SEARCH_KEYWORD_TOTAL.increment(labels: { keyword: query.to_s.strip.downcase, hit: hit }) unless query.to_s.strip.empty?
 
   json results: results
 end

--- a/ruby-app/routes/api_routes.rb
+++ b/ruby-app/routes/api_routes.rb
@@ -46,7 +46,7 @@ get '/api/search' do
 
   SEARCH_QUERIES_TOTAL.increment(labels: { language: language_label_for(query), hit: hit })
   SEARCH_DURATION_SECONDS.observe(duration, labels: { language: language_label_for(query), hit: hit })
-  SEARCH_KEYWORD_TOTAL.increment(labels: { keyword: query.to_s.strip.downcase, hit: hit }) unless query.to_s.strip.empty?
+  SEARCH_KEYWORD_TOTAL.increment(labels: { hit: hit }) unless query.to_s.strip.empty?
 
   json results: results
 end

--- a/ruby-app/routes/html_routes.rb
+++ b/ruby-app/routes/html_routes.rb
@@ -18,7 +18,7 @@ get '/' do
 
     SEARCH_QUERIES_TOTAL.increment(labels: { language: language_label_for(query), hit: hit })
     SEARCH_DURATION_SECONDS.observe(duration, labels: { language: language_label_for(query), hit: hit })
-    SEARCH_KEYWORD_TOTAL.increment(labels: { keyword: query.to_s.strip.downcase, hit: hit }) unless query.to_s.strip.empty?
+    SEARCH_KEYWORD_TOTAL.increment(labels: { hit: hit }) unless query.to_s.strip.empty?
 
     erb :search, locals: { search_results: results, query: query }
   end

--- a/ruby-app/routes/html_routes.rb
+++ b/ruby-app/routes/html_routes.rb
@@ -18,6 +18,7 @@ get '/' do
 
     SEARCH_QUERIES_TOTAL.increment(labels: { language: language_label_for(query), hit: hit })
     SEARCH_DURATION_SECONDS.observe(duration, labels: { language: language_label_for(query), hit: hit })
+    SEARCH_KEYWORD_TOTAL.increment(labels: { keyword: query.to_s.strip.downcase, hit: hit }) unless query.to_s.strip.empty?
 
     erb :search, locals: { search_results: results, query: query }
   end


### PR DESCRIPTION
### What has changed?
Added search_keyword_total metric to track individual search queries. Created business and security Grafana dashboards with meaningful observability.

### Why did it need to be changed?
Enable product insights (top searches, gaps in content) and security monitoring (failed logins, access denials, anomalies).

### How did you change it?
Added SEARCH_KEYWORD_TOTAL counter to metrics.rb, incremented in search handlers. Created business-observability.json and security-observability.json dashboards in monitoring repo. Added monitoring documentation.

***

**Checklist**

- [x] Application compiles
- [x] Documentation added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Added a new Prometheus counter constant SEARCH_KEYWORD_TOTAL and increments in both HTML and API search routes; added monitoring documentation describing Prometheus/Grafana setup and dashboards.

Key facts:
- Code: ruby-app/metrics/metrics.rb defines SEARCH_KEYWORD_TOTAL with labels: [:hit].
- Instrumentation: ruby-app/routes/api_routes.rb and ruby-app/routes/html_routes.rb increment SEARCH_KEYWORD_TOTAL when query is non-empty (labels: { hit: hit }).
- Docs: documentation/devops/monitoring.md documents the Prometheus/Grafana stack and describes a search_keyword_total counter with labels `keyword` and `hit`, and references two dashboards (UIDs: business-observability, security-observability).

## Issues & Actionable Feedback

### 1) Mismatch: documentation claims a `keyword` label but code does not expose it
- Problem: monitoring.md documents search_keyword_total with labels `keyword` and `hit`, but SEARCH_KEYWORD_TOTAL is registered only with label `hit` and increments pass only `hit`. This creates a documentation ↔ code mismatch and will confuse dashboard authors and monitoring pipelines.
- Suggestion (GitHub suggestion format) — either add `keyword` to metric registration and include a normalized keyword when incrementing, or update the docs to remove `keyword` and explain why (cardinality mitigation).
  - To add the label (beware cardinality):
    ```suggestion
    # ruby-app/metrics/metrics.rb
    SEARCH_KEYWORD_TOTAL = fetch_or_register_counter(
      PROM_REGISTRY,
      :search_keyword_total,
      docstring: 'Search queries broken down by keyword and hit/miss',
      labels: %i[keyword hit]
    )
    ```
    ```suggestion
    # ruby-app/routes/api_routes.rb and ruby-app/routes/html_routes.rb
    normalized_keyword = query.to_s.strip.downcase
    SEARCH_KEYWORD_TOTAL.increment(labels: { keyword: normalized_keyword, hit: hit }) unless normalized_keyword.empty?
    ```
  - Or, to align docs to current implementation, update monitoring.md to remove `keyword` from the metric reference and clarify the intentional omission (cardinality control, top-k approach, or aggregator/exporter approach).

Why this matters: undocumented labels cause dashboards to fail and Prometheus queries to misbehave; adding raw keywords increases cardinality and risks Prometheus performance.

### 2) Missing dashboard JSON files / provisioning mismatch
- Observation: monitoring.md references dashboard UIDs `business-observability` and `security-observability` and GitOps provisioning, but there are no dashboard JSON files in this repo (the claimed JSON files are not present).
- Action needed: add the JSON dashboard files into the repo (if GitOps provisioning is intended) or update documentation to point to the separate monitoring repo and describe how dashboards are provisioned/where they live.

### 3) Secrets & access guidance in docs
- Concern: monitoring.md states "admin credentials in `.env`" for Grafana. Documenting location of secrets or implying plaintext storage can lead to accidental leaks.
- Recommendation: document a secure secret storage practice (e.g., Vault/Secrets Manager or restricted CI secrets) and remove explicit reference to storing admin credentials in a repo-controlled `.env`.

### 4) Cardinality & measurement guidance
- Positive: code avoids incrementing for blank queries and uses `hit` label only, which helps control cardinality.
- Risk: if you add a `keyword` label, include mitigations (top-k aggregation, hashing with controlled buckets, or separate low-TPS exporter). Document the expected cardinality and retention/Prometheus scrape rules.

### 5) Commit atomicity (DevOps: Automation & Sharing)
- The PR has ~82 lines changed in a single commit. Since 82 > 1 commit × 50, please split into more atomic commits:
  1. Metric & instrumentation changes (metrics.rb, api_routes.rb, html_routes.rb)
  2. Documentation and provisioning files (monitoring.md and dashboard JSONs if added)
- Rationale: smaller commits improve reviewability, tracing, and rollback.

## Tests & Edge Cases to cover
- Ensure metrics endpoint still protected by MONITORING_IP and returns expected Prometheus format.
- If adding `keyword` label: tests should verify normalization (strip + downcase), and that blank queries are skipped.
- Load test Prometheus/Promtool with higher cardinality (simulate many unique keywords) to validate scrape and storage behavior before enabling keywords in production.

## Short next steps (prioritized)
1. Decide whether SEARCH_KEYWORD_TOTAL should include `keyword`:
   - If yes: implement label + normalized increment and add cardinality mitigations; update tests and docs.
   - If no: update documentation to remove `keyword` label and clearly state reason.
2. Add or point to Grafana dashboard JSON files, or update docs to reference the actual provisioning repo.
3. Remove or secure documented references to storing admin credentials in `.env`.
4. Split the PR into two commits (instrumentation + docs/dashboards) and push.

## DevOps perspective (concise)
- Measurement: metric added—good; ensure documented labels match code.
- Automation: GitOps for dashboards is stated—ensure dashboard files exist or document the external repo.
- Sharing: update docs to avoid exposing secrets and to be precise for on-call/monitoring owners.
- Culture & Lean: split responsibilities into atomic commits for clearer reviews and easier troubleshooting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ripmarkus/whoknows_ripmarkus/pull/245)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->