### PR TITLE
chore: upgraded the dependencies to fix security vulnerabilities

### DIFF
--- a/ruby-app/Gemfile
+++ b/ruby-app/Gemfile
@@ -20,6 +20,7 @@ gem "activesupport", ">= 8.1.2.1"
 gem "loofah", ">= 2.25.1"
 gem "actionview", ">= 8.1.2.1"
 gem "actionpack", ">= 8.1.2.1"
+gem "nokogiri", ">= 1.19.3"
 
 group :development do
   gem 'rerun'

--- a/ruby-app/Gemfile.lock
+++ b/ruby-app/Gemfile.lock
@@ -71,11 +71,11 @@ GEM
       prism (~> 1.5)
     mustermann (3.1.1)
     nio4r (2.7.5)
-    nokogiri (1.19.2-arm64-darwin)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.2-x64-mingw-ucrt)
+    nokogiri (1.19.3-x64-mingw-ucrt)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (2.0.1)
     parser (3.3.11.1)
@@ -211,6 +211,7 @@ DEPENDENCIES
   dotenv
   json (>= 2.19.2)
   loofah (>= 2.25.1)
+  nokogiri (>= 1.19.3)
   pg
   prometheus-client
   puma


### PR DESCRIPTION
### What has changed?

Gemfile and Gemfile.lock to pin vulnerable dependencies to their patched versions.

### Why did it need to be changed?

Dependabot security alerts flagged vulnerabilities in these dependencies.

### How did you change it?

Explicitly pinned the vulnerable gems with minimum version constraints in the Gemfile and ran bundle update to resolve and lock the patched versions in Gemfile.lock.

***

**Checklist**

- [ ] Application compiles
- [ ] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Commit Atomicity Issue

This PR violates atomic commit principles significantly:
- **780 files changed** in **1 commit** with **108,466+ lines added**
- Per DevOps standards: since files changed (780) >> commits (1) + 1, this should be split into multiple atomic commits

The PR title and description claim this addresses "security vulnerabilities in dependencies," but the actual commit bundles this with:
- Complete repository initialization (documentation, GitHub workflows, views, configuration files)
- Entire `vendor/ruby` directory (typically not committed to Git)
- Multiple unrelated features (.coderabbit.yaml, Dependabot config, CI/CD workflows, etc.)

**Recommendation:** Break this into separate, focused commits:
1. Security dependency upgrades only (Gemfile + Gemfile.lock)
2. Repository structure and documentation (separate commit)
3. Tooling configuration (separate commit)

## Dependency Pinning Review

The Gemfile additions address known vulnerabilities:
- `nokogiri >= 1.19.3` - adds XML parsing dependency with minimum version constraint
- `rack >= 3.2.6` - security-critical web server dependency
- `bcrypt >= 3.1.22`, `loofah >= 2.25.1`, `activesupport >= 8.1.2.1` - patched versions for known CVEs

**Concern:** The PR description states "Gemfile and Gemfile.lock were modified," but committing `vendor/ruby/` (compiled native extensions and all gem source code) is not standard practice. Dependencies should be installed via `bundle install` during deployment, not committed to the repository. This bloats the repo and creates maintenance issues.

## Missing Documentation

The PR checklist items remain unchecked:
- "Application compiles" - no verification provided
- "Documentation added" - no documentation of which vulnerabilities were patched or why each version constraint was chosen

Consider documenting: which Dependabot alerts prompted these changes, CVE identifiers, and why these minimum versions were selected.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ripmarkus/whoknows_ripmarkus/pull/246)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->