### PR TITLE
ci: add OWASP ZAP dynamic security scan

### DIFF
--- a/.github/workflows/owasp_zap.yml
+++ b/.github/workflows/owasp_zap.yml
@@ -11,8 +11,10 @@ jobs:
   zap_scan:
     name: OWASP ZAP Baseline Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Start application
         working-directory: ruby-app
@@ -46,7 +48,7 @@ jobs:
               -I
 
       - name: Upload ZAP report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: zap-security-report

--- a/.github/workflows/owasp_zap.yml
+++ b/.github/workflows/owasp_zap.yml
@@ -1,0 +1,46 @@
+name: OWASP ZAP Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  zap_scan:
+    name: OWASP ZAP Baseline Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start application
+        working-directory: ruby-app
+        run: docker compose up -d --build
+
+      - name: Wait for application to be healthy
+        run: |
+          curl --retry 15 --retry-delay 5 --retry-connrefused -sf http://localhost:8080/ || \
+          (docker compose -f ruby-app/compose.yaml logs web && exit 1)
+
+      - name: Run ZAP baseline scan
+        run: |
+          docker run --network host \
+            -v ${{ github.workspace }}:/zap/wrk/:rw \
+            ghcr.io/zaproxy/zaproxy:stable \
+            zap-baseline.py \
+              -t http://localhost:8080 \
+              -r zap-report.html \
+              -I
+
+      - name: Upload ZAP report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: zap-security-report
+          path: zap-report.html
+
+      - name: Tear down application
+        if: always()
+        working-directory: ruby-app
+        run: docker compose down

--- a/.github/workflows/owasp_zap.yml
+++ b/.github/workflows/owasp_zap.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Run ZAP baseline scan
         run: |
+          touch zap-report.html && chmod 777 zap-report.html
           docker run --network host \
             -v ${{ github.workspace }}:/zap/wrk/:rw \
             ghcr.io/zaproxy/zaproxy:stable \

--- a/.github/workflows/owasp_zap.yml
+++ b/.github/workflows/owasp_zap.yml
@@ -20,8 +20,19 @@ jobs:
 
       - name: Wait for application to be healthy
         run: |
-          curl --retry 15 --retry-delay 5 --retry-connrefused -sf http://localhost:8080/ || \
-          (docker compose -f ruby-app/compose.yaml logs web && exit 1)
+          for i in $(seq 1 15); do
+            if curl -sf http://localhost:8080/; then
+              echo "App is up!"
+              break
+            fi
+            echo "Attempt $i failed, waiting..."
+            sleep 5
+            if [ $i -eq 15 ]; then
+              echo "App failed to start, printing logs..."
+              docker compose -f ruby-app/compose.yaml logs web
+              exit 1
+            fi
+          done
 
       - name: Run ZAP baseline scan
         run: |

--- a/documentation/devops/security.md
+++ b/documentation/devops/security.md
@@ -15,9 +15,18 @@ The `owasp_zap.yml` workflow runs on every push and pull request to `main`. It s
 
 **Why `-I`:** The scan uses the `-I` flag so warnings do not fail the build - the goal is visibility, not blocking PRs on informational findings. Promote issues to failures selectively by using a ZAP rules config file if needed in future.
 
+**Known warnings from first scan:**
+- Missing CSP and Permissions-Policy headers
+- Cookie without SameSite attribute
+- Absence of Anti-CSRF tokens on login/register
+- Debug error messages exposed on `/login` and `/register` (500 responses)
+- Cross-Origin-Embedder-Policy header missing
+
+These are tracked as future hardening work, not blockers.
+
 ## RuboCop - Code Quality
 
-RuboCop enforces style and complexity rules via `.rubocop.yml`. While primarily a linter, it catches patterns that can lead to security issues (e.g., overly complex methods, unsafe string handling). Configured in `rubocop.yaml` and runs on every PR.
+RuboCop enforces style and complexity rules. While primarily a linter, it catches patterns that can lead to security issues (e.g., overly complex methods, unsafe string handling). It runs on every PR via the `.github/workflows/rubocop.yaml` workflow.
 
 ## Dependency Scanning
 

--- a/documentation/devops/security.md
+++ b/documentation/devops/security.md
@@ -1,0 +1,24 @@
+# Security Tooling
+
+## OWASP ZAP - Dynamic Application Security Testing
+
+The `owasp_zap.yml` workflow runs on every push and pull request to `main`. It spins up the full application stack via Docker Compose, waits for the app to be healthy, then runs a **ZAP baseline scan** - a passive scan that spiders the app and flags common vulnerabilities without actively attacking it.
+
+**What it checks for:**
+- Missing security headers (CSP, X-Frame-Options, HSTS, etc.)
+- Information disclosure (server banners, stack traces)
+- Insecure cookie flags (missing `HttpOnly`, `Secure`, `SameSite`)
+- Clickjacking exposure
+- Other OWASP Top 10 passive indicators
+
+**Report:** The HTML report is uploaded as a workflow artifact (`zap-security-report`) on every run, including failed runs. Download it from the Actions summary page to see the full findings broken down by risk level (High / Medium / Low / Informational).
+
+**Why `-I`:** The scan uses the `-I` flag so warnings do not fail the build - the goal is visibility, not blocking PRs on informational findings. Promote issues to failures selectively by using a ZAP rules config file if needed in future.
+
+## RuboCop - Code Quality
+
+RuboCop enforces style and complexity rules via `.rubocop.yml`. While primarily a linter, it catches patterns that can lead to security issues (e.g., overly complex methods, unsafe string handling). Configured in `rubocop.yaml` and runs on every PR.
+
+## Dependency Scanning
+
+Dependency vulnerabilities are tracked via Dependabot and reviewed periodically. See the `security/dependency-upgrades` PRs in the git history for examples of routine upgrades.


### PR DESCRIPTION
### What has changed?

Added OWASP ZAP baseline scan workflow and security tooling documentation.

### Why did it need to be changed?

Closes #250 - we needed dynamic application security testing in CI to catch common vulnerabilities like missing security headers, insecure cookies, and OWASP Top 10 issues.

### How did you change it?

- Added `.github/workflows/owasp_zap.yml` - starts the app via Docker Compose, waits for health, runs a ZAP passive baseline scan, and uploads the HTML report as a `zap-security-report` artifact
- Added `documentation/devops/security.md` covering ZAP, RuboCop, and Dependabot

***

**Checklist**

- [x] Application compiles
- [x] Documentation added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR claims to add an OWASP ZAP baseline scan workflow and security documentation, but the last commit includes the entire application and vendor files (776 files; large binary/library files; massive line additions). This is not an atomic, focused change and is unsafe to merge as-is.

Why this is a problem (DevOps principles):
- Culture / Sharing: Large, mixed commits make peer review and knowledge sharing difficult.
- Automation / Lean: CI and tooling changes should be small and verifiable; bundling the whole app defeats incremental automation.
- Measurement: Hard to trace regressions or metrics to a single change when many unrelated files are included.

What was added (intended):
- .github/workflows/owasp_zap.yml — starts app via Docker Compose, waits for health, runs ZAP baseline scan, uploads zap-report.html artifact, tears down services.
- documentation/devops/security.md — documents ZAP, RuboCop, Dependabot.
- Commits fixing health checks and report file permissions in the workflow.

Key issues
1. Not-atomic commit
   - Files changed (776) >> commits (1) + 1 and lines changed >> commits × 50. This violates “atomic commits”; impossible to review or bisect.

2. Large vendor/content included
   - Ruby vendor/ and many gem sources/binaries, images, and test outputs are committed. This inflates the repo and hides the actual CI/doc change.

3. Security / risk considerations
   - Committed vendor binaries increase attack surface and risk accidental secret inclusion; inspect for embedded credentials.
   - .env.example is present (good), but verify no real .env or secrets were added in commit history or images.
   - The ZAP workflow appears to run a passive baseline scan (non-blocking). Ensure team knows it won’t fail CI on warnings (-I flag) and plan for triage of results.

4. Documentation
   - security.md addition aligns with objective but must reference the actual workflow location and expected artifact name. Ensure documentation notes how to interpret ZAP baseline findings and next steps.

Recommended actions (do not merge until done)
- Stop—do not merge this PR as-is.
- Confirm intent: was the huge commit accidental or intentional?
- If accidental: create a focused PR containing only:
  - .github/workflows/owasp_zap.yml
  - documentation/devops/security.md
  - Any small workflow fixes (health-check / permissions)
- If intentional: split into atomic commits (suggested ordering):
  1. Project/source code (app) — if needed
  2. Vendor/gems as a separate commit (or, better, remove vendor from VCS)
  3. CI/workflow changes
  4. Documentation

Concrete git suggestions (GitHub suggestion format)
- Remove vendor files from the repo and add to .gitignore:
  ```suggestion
  # Remove vendor directory from history for new commits
  git rm -r --cached ruby-app/vendor
  echo "ruby-app/vendor/" >> .gitignore
  git commit -m "chore: remove vendor files from VCS and ignore"
  ```
- Create a focused branch/PR with only workflow + docs:
  ```suggestion
  git checkout -b feature/owasp-zap-workflow
  git restore --source=<previous-clean-base> --staged --worktree -- .github/workflows/owasp_zap.yml documentation/devops/security.md
  git add .github/workflows/owasp_zap.yml documentation/devops/security.md
  git commit -m "ci: add OWASP ZAP baseline scan workflow and security docs"
  git push origin feature/owasp-zap-workflow
  ```

Minor technical notes about the workflow (for reviewer learning)
- Health-check loop with curl --retry is appropriate; ensure app binds to localhost:8080 in compose.
- Running ZAP with host networking can be fine for GitHub-hosted runners but document implications.
- Baseline scan using -I (ignore passives) is non-blocking — decide whether CI should fail on high-risk findings later.

If you want, I can:
- Prepare a minimal patch/branch containing only the workflow and documentation files.
- Scan the repo for possible committed secrets (.env, credentials).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ripmarkus/whoknows_ripmarkus/pull/259)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->