### PR TITLE
chore: add git hooks for secrets detection and commit validation

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Enforce Conventional Commits format
+
+commit_msg=$(cat "$1")
+pattern="^(feat|fix|chore|docs|ci|refactor|test|style|perf|revert)(\(.+\))?: .+"
+
+if ! echo "$commit_msg" | grep -qE "$pattern"; then
+  echo "Invalid commit message: '$commit_msg'"
+  echo ""
+  echo "Must match Conventional Commits format:"
+  echo "  <type>: <description>"
+  echo ""
+  echo "Allowed types: feat, fix, chore, docs, ci, refactor, test, style, perf, revert"
+  echo "Example: feat: add search endpoint"
+  exit 1
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Scan staged files for secrets using gitleaks
+
+if command -v gitleaks >/dev/null 2>&1; then
+  gitleaks protect --staged --no-banner -q
+  if [ $? -ne 0 ]; then
+    echo "gitleaks: secrets detected in staged files. Commit blocked."
+    echo "Run 'gitleaks protect --staged' to see details."
+    exit 1
+  fi
+else
+  echo "gitleaks not installed - skipping secrets scan."
+  echo "Install it: https://github.com/gitleaks/gitleaks#installing"
+fi

--- a/documentation/development/contributions.md
+++ b/documentation/development/contributions.md
@@ -31,6 +31,32 @@ To create a new branch, use the follow command in the cloned repo:
 git checkout -b type/<branch-name>
 ```
 
+## Git Hooks
+
+We use Git hooks stored in `.githooks/` to enforce commit quality locally. Run this once after cloning:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Two hooks are active:
+
+- **pre-commit** - scans staged files for secrets using [gitleaks](https://github.com/gitleaks/gitleaks). Install it before committing:
+  ```bash
+  # macOS
+  brew install gitleaks
+
+  # Linux
+  sudo apt install gitleaks
+
+  # Windows (winget)
+  winget install gitleaks
+  # or download the .exe from https://github.com/gitleaks/gitleaks/releases
+  ```
+  The hook will warn but not block if gitleaks is not installed.
+
+- **commit-msg** - rejects commits that do not follow the Conventional Commits format (see below).
+
 ## Commits
 
 We love commits and we love to commit every time we have added a new:


### PR DESCRIPTION
### What has changed?

Added `.githooks/` with a pre-commit secrets scan and a commit-msg format enforcer.

### Why did it need to be changed?

Closes #258 - prevents secrets from being committed and enforces Conventional Commits format locally before code reaches CI.

### How did you change it?

- `.githooks/pre-commit` - runs gitleaks on staged files, warns if gitleaks is not installed
- `.githooks/commit-msg` - rejects commits that do not match the Conventional Commits pattern
- Updated `documentation/development/contributions.md` with setup instructions for macOS, Linux, and Windows

***

**Checklist**

- [x] Application compiles
- [x] Documentation added