### PR TITLE
chore: add compose.dev.yml with hot-reloading

### DIFF
--- a/documentation/devops/docker.md
+++ b/documentation/devops/docker.md
@@ -56,6 +56,26 @@ EXPOSE 4567
 CMD ["ruby", "app.rb", "-o", "0.0.0.0", "-p", "8080"]
 ```
 
+## Dev vs Production Compose
+
+There are two Compose files in `ruby-app/`:
+
+| File | Purpose |
+|---|---|
+| `compose.yaml` | Production - no bind mounts, uses the built image |
+| `compose.dev.yml` | Development - bind mounts source code, uses `rerun` for hot-reloading |
+
+To run locally with hot-reloading:
+
+```bash
+cd ruby-app
+docker compose -f compose.dev.yml up --build
+```
+
+Any change to a `.rb` file will automatically restart the app inside the container. The production `compose.yaml` is never used for local development - it exists for CI and the deployment pipeline.
+
+---
+
 For production, we don't want to use CDN for serving the tailwind styling. Instead we want to build it with the app.
 
 The following has been added to the Dockerfile:

--- a/ruby-app/compose.dev.yml
+++ b/ruby-app/compose.dev.yml
@@ -1,0 +1,38 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: whoknows_development
+      POSTGRES_USER: whoknows
+      POSTGRES_PASSWORD: secret
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U whoknows -d whoknows_development"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - postgres_data_dev:/var/lib/postgresql/data
+
+  web:
+    build:
+      context: .
+      target: build
+    command: bundle exec rerun -- ruby app.rb -o 0.0.0.0 -p 8080
+    environment:
+      PORT: 8080
+      APP_ENV: development
+      RACK_ENV: development
+      SINATRA_ENV: development
+      DATABASE_URL: postgres://whoknows:secret@db:5432/whoknows_development
+    ports:
+      - "8080:8080"
+    volumes:
+      - .:/app
+      - app_logs_dev:/app/logs
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  postgres_data_dev:
+  app_logs_dev:


### PR DESCRIPTION
### What has changed?

Added a development Compose file with hot-reloading.

### Why did it need to be changed?

Closes #254 - the production `compose.yaml` has no bind mounts so every code change requires a full image rebuild. Developers needed a faster local setup.

### How did you change it?

- Added `ruby-app/compose.dev.yml` - bind mounts the source directory and uses `rerun` (already in the dev Gemfile) to restart the app on file changes
- Updated `documentation/devops/docker.md` with a dev vs production breakdown and usage instructions

***

**Checklist**

- [x] Application compiles
- [x] Documentation added