### PR TITLE
Fix/dockerport

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -19,10 +19,12 @@ jobs:
       - name: Deploy
         run: |
           ssh -i ~/.ssh/homeserver -o StrictHostKeyChecking=no \
-            "${{ secrets.SERVER_USER }}@${{ secrets.SERVER_IP }}" << 'DEPLOY'
+            "${{ secrets.SERVER_USER }}@${{ secrets.SERVER_IP }}" << "DEPLOY"
           set -eo pipefail
 
           cd /opt/docker/devops/whoknows_ripmarkus/ruby-app
+
+          set -a && source .env && set +a
 
           echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USERNAME }}" --password-stdin
 
@@ -30,8 +32,8 @@ jobs:
 
           # Backup før deploy
           mkdir -p /opt/backups/whoknows
-          BACKUP="/opt/backups/whoknows/pre_deploy_$(date +%Y%m%d_%H%M%S).dump"
-          docker compose exec -T db pg_dump -U whoknows -d whoknows > "$BACKUP"
+          BACKUP="/opt/backups/whoknows/pre_deploy_\$(date +%Y%m%d_%H%M%S).dump"
+          docker compose exec -T db pg_dump -U \$POSTGRES_USER -d \$POSTGRES_DB > "\$BACKUP"
           ls -t /opt/backups/whoknows/*.dump | tail -n +11 | xargs -r rm -f
 
           docker compose pull web

--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -26,7 +26,7 @@ jobs:
 
           echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USERNAME }}" --password-stdin
 
-          wget -O compose.yaml https://raw.githubusercontent.com/ripmarkus/whoknows_ripmarkus/refs/heads/main/ruby-app/compose.yaml
+          wget -O compose.yaml https://raw.githubusercontent.com/ripmarkus/whoknows_ripmarkus/refs/heads/main/ruby-app/docker_compose.yaml
 
           # Backup før deploy
           mkdir -p /opt/backups/whoknows

--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -5,7 +5,6 @@ on:
     workflows: ["Ruby CI"]
     types: [completed]
     branches: [main]
-
 jobs:
   deploy:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
@@ -17,46 +16,24 @@ jobs:
           echo "${{ secrets.SSH_KEY }}" > ~/.ssh/homeserver
           chmod 600 ~/.ssh/homeserver
 
-      - name: Deploy app
-        env:
-          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+      - name: Deploy
         run: |
-          ssh -i ~/.ssh/homeserver -o StrictHostKeyChecking=no "${{ secrets.SERVER_USER }}@${{ secrets.SERVER_IP }}" 'bash -s' << EOF
-          set -uo pipefail
+          ssh -i ~/.ssh/homeserver -o StrictHostKeyChecking=no \
+            "${{ secrets.SERVER_USER }}@${{ secrets.SERVER_IP }}" << 'DEPLOY'
+          set -eo pipefail
 
-          echo "Logging in to GHCR..."
-          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
-
-          echo "Changing to app directory..."
           cd /opt/docker/devops/whoknows_ripmarkus/ruby-app
 
-          echo "Checking if database container is running..."
-          DB_RUNNING=\$(docker compose ps --services --status running | grep -c '^db$' || true)
+          echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USERNAME }}" --password-stdin
 
-          if [ "\$DB_RUNNING" -gt 0 ]; then
-            echo "Database is running. Creating pre-deploy backup..."
-            BACKUP_DIR="/opt/backups/whoknows"
-            BACKUP_FILE="\$BACKUP_DIR/pre_deploy_\$(date +%Y%m%d_%H%M%S).dump"
-            mkdir -p "\$BACKUP_DIR"
+          wget -O compose.yaml https://raw.githubusercontent.com/ripmarkus/whoknows_ripmarkus/refs/heads/main/ruby-app/compose.yaml
 
-            if docker compose exec -T db pg_dump -U whoknows --format=custom whoknows > "\$BACKUP_FILE" < /dev/null; then
-              echo "Backup created: \$BACKUP_FILE"
-              echo "Cleaning old backups (keeping last 10)..."
-              ls -t "\$BACKUP_DIR"/*.dump 2>/dev/null | tail -n +11 | xargs -r rm -f || true
-            else
-              rm -f "\$BACKUP_FILE"
-              echo "WARNING: Backup failed. Continuing deployment anyway."
-            fi
-          else
-            echo "WARNING: Database container is not running. Skipping backup."
-          fi
+          # Backup før deploy
+          mkdir -p /opt/backups/whoknows
+          BACKUP="/opt/backups/whoknows/pre_deploy_$(date +%Y%m%d_%H%M%S).dump"
+          docker compose exec -T db pg_dump -U whoknows -d whoknows > "$BACKUP"
+          ls -t /opt/backups/whoknows/*.dump | tail -n +11 | xargs -r rm -f
 
-          echo "Pulling latest web image..."
-          docker compose pull web || exit 1
-
-          echo "Restarting web container..."
-          docker compose up -d --no-deps web || exit 1
-
-          echo "Deployment complete."
-          EOF
+          docker compose pull web
+          docker compose up -d
+          DEPLOY

--- a/documentation/devops/server-directory-structure.md
+++ b/documentation/devops/server-directory-structure.md
@@ -6,29 +6,29 @@ This document describes the directory structure and locations of active configur
 
 All Docker and deployment structures are strictly isolated inside the `/opt/` system directory using the following conventions:
 
-*   **System Decoupling:** Keeping configurations entirely out of individual `/home/` directories ensures that files remain accessible and persistent regardless of which team member is logged in.
-*   **Centralized Backup Scope:** Consolidating all infrastructure configurations inside a single root directory (`/opt/docker/devops/`) allows for simple, unified snapshotting and disaster recovery.
-*   **FHS Compliance:** Adhering to the standard Linux Filesystem Hierarchy Standard by placing self-contained, optional third-party stacks into the global `/opt/` space.
-
+- **System Decoupling:** Keeping configurations entirely out of individual `/home/` directories ensures that files remain accessible and persistent regardless of which team member is logged in.
+- **Centralized Backup Scope:** Consolidating all infrastructure configurations inside a single root directory (`/opt/docker/devops/`) allows for simple, unified snapshotting and disaster recovery.
+- **FHS Compliance:** Adhering to the standard Linux Filesystem Hierarchy Standard by placing self-contained, optional third-party stacks into the global `/opt/` space.
 
 ## Global Paths
 
 All active production files related to Docker and server management are located in the main system directory under opt:
 
-*   Path: `/opt/docker/devops/`
+- Path: `/opt/docker/devops/`
 
 ---
 
 ## Project Structure
 
 ### Ruby Application, Node Exporter & Nginx Proxy
+
 This directory is the central hub of the server. It contains the source code, database, web server, and the monitoring agent (Node Exporter). Everything runs within a closed, internal Docker network under this shared configuration.
 
-*   Path: `/opt/docker/devops/whoknows_ripmarkus/ruby-app/`
-*   Key Files:
-    *   `compose.yaml` — The active Docker Compose file managing the database, Ruby app, Nginx, and the active Node Exporter.
-    *   `nginx.conf` — The web server configuration file handling the domain, SSL certificates, and secure endpoints (`/metrics/ruby` and `/metrics/node`) for external monitoring.
-    *   `Dockerfile` — The recipe file used to build the internal Ruby application environment.
+- Path: `/opt/docker/devops/whoknows_ripmarkus/ruby-app/`
+- Key Files:
+  - `compose.yaml` — The active Docker Compose file managing the database, Ruby app, Nginx, and the active Node Exporter.
+  - `nginx.conf` — The web server configuration file handling the domain, SSL certificates, and secure endpoints (`/metrics/ruby` and `/metrics/node`) for external monitoring.
+  - `Dockerfile` — The recipe file used to build the internal Ruby application environment.
 
 ---
 
@@ -37,6 +37,7 @@ This directory is the central hub of the server. It contains the source code, da
 Use these absolute paths to jump directly to the relevant areas on the server.
 
 Go directly to the active configuration files for the entire setup:
+
 ```bash
 cd /opt/docker/devops/whoknows_ripmarkus/ruby-app/
 ```

--- a/ruby-app/compose.yaml
+++ b/ruby-app/compose.yaml
@@ -1,65 +1,40 @@
 services:
   db:
     image: postgres:16-alpine
-    restart: unless-stopped
-    env_file:
-      - .env
     environment:
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
+      POSTGRES_DB: whoknows_test
+      POSTGRES_USER: whoknows
+      POSTGRES_PASSWORD: secret
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      test: ["CMD-SHELL", "pg_isready -U whoknows -d whoknows_test"]
       interval: 5s
       timeout: 5s
       retries: 10
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
 
   web:
-    image: ghcr.io/ripmarkus/whoknows_ripmarkus:main
-    restart: unless-stopped
-    env_file:
-      - .env
+    build: .
+    image: whoknows_ripmarkus:test
     environment:
+      PORT: 8080
       APP_ENV: production
       RACK_ENV: production
       SINATRA_ENV: production
-      DATABASE_URL: ${DATABASE_URL}
-      PORT: 8080
-    depends_on:
-      - db
-    healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/ || exit 1"]
-      interval: 10s
-      timeout: 3s
-      retries: 5
-      start_period: 15s
-
-  nginx:
-    image: nginx:alpine
-    restart: unless-stopped
-    depends_on:
-      - web
+      DATABASE_URL: postgres://whoknows:secret@db:5432/whoknows_test
     ports:
-      - "80:80"
-      - "443:443"
+      - "8080:8080"
     volumes:
-      - /etc/letsencrypt:/etc/letsencrypt:ro
-      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
-
-  node_exporter:
-    image: prom/node-exporter:v1.8.2
-    restart: unless-stopped
-    command:
-      - --path.rootfs=/host
-      - --path.procfs=/host/proc
-      - --path.sysfs=/host/sys
-      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
-    volumes:
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
-      - /:/host:ro,rslave
+      - app_logs:/app/logs
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/ >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
 
 volumes:
   postgres_data:
+  app_logs:

--- a/ruby-app/compose.yaml
+++ b/ruby-app/compose.yaml
@@ -1,40 +1,65 @@
 services:
   db:
     image: postgres:16-alpine
+    restart: unless-stopped
+    env_file:
+      - .env
     environment:
-      POSTGRES_DB: whoknows_test
-      POSTGRES_USER: whoknows
-      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U whoknows -d whoknows_test"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
       timeout: 5s
       retries: 10
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
 
   web:
-    build: .
-    image: whoknows_ripmarkus:test
+    image: ghcr.io/ripmarkus/whoknows_ripmarkus:main
+    restart: unless-stopped
+    env_file:
+      - .env
     environment:
-      PORT: 8080
       APP_ENV: production
       RACK_ENV: production
       SINATRA_ENV: production
-      DATABASE_URL: postgres://whoknows:secret@db:5432/whoknows_test
-    ports:
-      - "8080:8080"
-    volumes:
-      - app_logs:/app/logs
+      DATABASE_URL: ${DATABASE_URL}
+      PORT: 8080
     depends_on:
-      db:
-        condition: service_healthy
+      - db
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/ >/dev/null 2>&1 || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/ || exit 1"]
       interval: 10s
-      timeout: 5s
-      retries: 10
+      timeout: 3s
+      retries: 5
+      start_period: 15s
+
+  nginx:
+    image: nginx:alpine
+    restart: unless-stopped
+    depends_on:
+      - web
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+
+  node_exporter:
+    image: prom/node-exporter:v1.8.2
+    restart: unless-stopped
+    command:
+      - --path.rootfs=/host
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/host:ro,rslave
 
 volumes:
   postgres_data:
-  app_logs:

--- a/ruby-app/docker_compose.yaml
+++ b/ruby-app/docker_compose.yaml
@@ -1,0 +1,65 @@
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  web:
+    image: ghcr.io/ripmarkus/whoknows_ripmarkus:main
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      APP_ENV: production
+      RACK_ENV: production
+      SINATRA_ENV: production
+      DATABASE_URL: ${DATABASE_URL}
+      PORT: 8080
+    depends_on:
+      - db
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/ || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
+
+  nginx:
+    image: nginx:alpine
+    restart: unless-stopped
+    depends_on:
+      - web
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+
+  node_exporter:
+    image: prom/node-exporter:v1.8.2
+    restart: unless-stopped
+    command:
+      - --path.rootfs=/host
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/host:ro,rslave
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
### What has changed?
Our docker compose, and our CD workflow.
### Why did it need to be changed?
It was bad, and now it is fixed. Is is thoroughly described in the issue.
### How did you change it?
removing ports from docker compose and forcing our cd to get new docker compose every deployment from main branch
***

**Checklist**

- [ ] Application compiles
- [ ] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## DevOps Security & Architecture Concerns

### Critical: Missing Required Configuration Files
The `compose.yaml` now references `.env` file with `env_file` directive and interpolates `${DATABASE_URL}`, `${POSTGRES_DB}`, `${POSTGRES_USER}`, `${POSTGRES_PASSWORD}`, but **`.env` is not committed to the repository** (only `.env.example` exists). The CD workflow downloads `compose.yaml` but doesn't provide the `.env` file, which will cause deployment failures. The required `.env` file must either be:
- Pre-provisioned on the server (undocumented dependency)
- Created as part of deployment (not currently done)

### Critical: Missing nginx.conf
The `nginx` service in `compose.yaml` mounts `./nginx.conf:/etc/nginx/conf.d/default.conf:ro`, but this file doesn't exist in the repository. Deployments will fail with mount errors.

### Security: Hardcoded Database Credentials in CD Workflow
The deployment script hardcodes credentials in the backup command:
```yaml
docker compose exec -T db pg_dump -U whoknows -d whoknows > "$BACKUP"
```
These should be sourced from environment variables (e.g., `$POSTGRES_USER`, `$POSTGRES_DB`) to maintain consistency with the `.env` file and reduce credential exposure in workflow logs.

### Security: StrictHostKeyChecking Disabled
The workflow uses `ssh -o StrictHostKeyChecking=no`, which makes MITM attacks possible. Unless there's a specific operational reason, this should be removed to default to `yes`.

### Architecture: Service Dependency Ordering
The `web` service uses `depends_on: db` without a health condition, unlike `compose.dev.yml` which uses `condition: service_healthy`. This can cause race conditions where the web app starts before the database is ready. Consider:
```yaml
depends_on:
  db:
    condition: service_healthy
```

### Code Quality: Commit Atomicity
This PR makes 70 lines of changes across 3 files in 1 commit. According to DevOps best practices, commits should be atomic and focused. Consider splitting into:
1. Infrastructure changes (docker compose updates)
2. CD/deployment workflow updates
3. Documentation updates

This improves reviewability, traceability, and rollback granularity.

### Positive Security Improvements
The removal of direct host port mappings for node_exporter and the ruby-app is a good security hardening. Exposing only through the nginx reverse proxy reduces the attack surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->