### PR TITLE
remove ip-restriction from ruby, since nginx is the middleware now, a…

### DIFF
--- a/ruby-app/routes/api_routes.rb
+++ b/ruby-app/routes/api_routes.rb
@@ -5,11 +5,6 @@ get '/health' do
 end
 
 get '/metrics' do
-  monitoring_ip = ENV['MONITORING_IP'].to_s.strip
-  monitoring_ip = '127.0.0.1' if monitoring_ip.empty?
-
-  halt 403, 'Forbidden' unless allowed_ip?(current_request_ip, monitoring_ip)
-
   content_type 'text/plain; version=0.0.4; charset=utf-8'
   Prometheus::Client::Formats::Text.marshal(PROM_REGISTRY)
 end

--- a/ruby-app/spec/integration/metrics_spec.rb
+++ b/ruby-app/spec/integration/metrics_spec.rb
@@ -24,11 +24,6 @@ RSpec.describe 'Metrics endpoint and instrumentation' do
     matching_line.split(' ').last.to_f
   end
 
-  it 'blocks access to /metrics from non-monitoring IPs' do
-    get '/metrics', {}, { 'REMOTE_ADDR' => '10.0.0.55' }
-    expect(last_response.status).to eq(403)
-  end
-
   it 'allows access to /metrics from monitoring IP' do
     get '/metrics', {}, { 'REMOTE_ADDR' => '127.0.0.1' }
 


### PR DESCRIPTION
### What has changed?
nginx is our middleware now, and is the only right service to check for ips, since it is the only thing communicating with out actuall app and sends packets to the ruby app, so the 'allowed-ip' in the ruby is technically always wrong
### Why did it need to be changed?
doesnt work as intended.
### How did you change it?
changing the /metrics route on the routes/api_routes.rb
***

**Checklist**

- [ ] Application compiles
- [ ] Documentation added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR removes IP-based access control from the `/metrics` endpoint, trusting nginx as the sole gateway for external access. While the architectural rationale is sound—nginx handling incoming traffic eliminates the need for application-level IP filtering—**the PR has a critical flaw: it breaks existing tests**.

### Test Failure

The test suite in `ruby-app/spec/integration/metrics_spec.rb` includes tests that explicitly validate IP restriction behavior:
- **Line 27-30**: Test expects `/metrics` to return **403 Forbidden** for non-allowlisted IPs (e.g., `10.0.0.55`)
- **Line 32-38**: Test expects `/metrics` to return **200 OK** for the monitoring IP (`127.0.0.1`)

After this change, the first test will fail because the endpoint now returns 200 for all IPs. Tests that document expected security behavior cannot simply break—they must be updated or replaced with tests that validate the new nginx-based security model.

### Documentation Drift

Multiple documentation files still reference the old IP-restriction approach:
- `documentation/devops/monitoring.md` (line 9): States `/metrics` is "restricted to `MONITORING_IP`"
- `documentation/local/setup-guide-linuxvmacos.md` and `-windows.md`: Still instruct users to set `MONITORING_IP`
- `ruby-app/auth/README.md`: Documents `allowed_ip?` as protecting endpoints

The `allowed_ip?` helper function in `ruby-app/auth/auth.rb` remains in the codebase but is now unused.

### What's Missing

1. **Update or remove the metrics tests** that validate IP restriction (lines 27-30 of `metrics_spec.rb` will fail)
2. **Update documentation** to reflect the new nginx-based security model and remove references to `MONITORING_IP` filtering
3. **Clean up unused code**: Remove the `allowed_ip?` function from `ruby-app/auth/auth.rb` if it's truly unused elsewhere, or document why it's retained
4. **Add tests validating nginx access control** if the test suite should cover monitoring endpoint security

### DevOps Learning Note

This change reflects a sound DevOps principle—**defense in depth with proper separation of concerns**. Nginx as the edge server should handle external traffic filtering; the Ruby app should trust that nginx has vetted inbound connections. However, this requires all artifacts (code, tests, docs) to reflect the new security boundary. Leaving broken tests and outdated documentation defeats the purpose of automation and creates false confidence in the security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->