### PR TITLE
Add multi-arch local dev setup (x86 + ARM)

### DIFF
--- a/ruby-app/Dockerfile.dev
+++ b/ruby-app/Dockerfile.dev
@@ -1,0 +1,14 @@
+FROM ruby:3.3-alpine
+RUN apk add --no-cache \
+    build-base \
+    sqlite-dev \
+    postgresql-dev \
+    tzdata \
+    yaml-dev
+
+WORKDIR /app
+COPY Gemfile Gemfile.lock* ./
+RUN bundle install
+
+EXPOSE 8080
+CMD ["bundle", "exec", "rerun", "--", "ruby", "app.rb", "-o", "0.0.0.0", "-p", "8080"]

--- a/ruby-app/Gemfile.lock
+++ b/ruby-app/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
     drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
+    ffi (1.17.4-aarch64-linux-musl)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x64-mingw-ucrt)
     ffi (1.17.4-x86_64-linux-gnu)
@@ -71,16 +72,19 @@ GEM
       prism (~> 1.5)
     mustermann (3.1.1)
     nio4r (2.7.5)
+    nokogiri (1.19.3-aarch64-linux-musl)
+      racc (~> 1.4)
     nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.3-x64-mingw-ucrt)
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    parallel (2.0.1)
+    parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
+    pg (1.6.3-aarch64-linux-musl)
     pg (1.6.3-arm64-darwin)
     pg (1.6.3-x64-mingw-ucrt)
     pg (1.6.3-x86_64-linux)
@@ -179,10 +183,12 @@ GEM
       rack-protection (= 4.2.1)
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
+    sqlite3 (2.9.3-aarch64-linux-musl)
     sqlite3 (2.9.3-arm64-darwin)
     sqlite3 (2.9.3-x64-mingw-ucrt)
     sqlite3 (2.9.3-x86_64-linux-gnu)
     stringio (3.2.0)
+    tailwindcss-ruby (4.2.4-aarch64-linux-musl)
     tailwindcss-ruby (4.2.4-arm64-darwin)
     tailwindcss-ruby (4.2.4-x64-mingw-ucrt)
     tailwindcss-ruby (4.2.4-x86_64-linux-gnu)
@@ -199,6 +205,7 @@ GEM
     zeitwerk (2.7.5)
 
 PLATFORMS
+  aarch64-linux-musl
   arm64-darwin-23
   x64-mingw-ucrt
   x86_64-linux-gnu

--- a/ruby-app/Makefile
+++ b/ruby-app/Makefile
@@ -1,5 +1,8 @@
 # Makefile
-.PHONY: run install lint build up down help css
+DEV_COMPOSE := compose.dev.yml
+
+.PHONY: run install lint build up down help css \
+	dev dev-build dev-down dev-logs
 
 run:
 	ruby app.rb
@@ -22,11 +25,29 @@ up:
 down:
 	docker compose down
 
+# --- Local dev (Docker Compose, multi-arch: works on x86 + ARM) ---
+
+dev-build:
+	docker compose -f $(DEV_COMPOSE) build
+
+dev:
+	docker compose -f $(DEV_COMPOSE) up -d --build
+
+dev-down:
+	docker compose -f $(DEV_COMPOSE) down
+
+dev-logs:
+	docker compose -f $(DEV_COMPOSE) logs -f
+
 help:
-	@echo "make run      - Run app locally (Ruby + SQLite)"
-	@echo "make css      - Run Tailwind CSS watcher in background"
-	@echo "make install  - Bundle install dependencies"
-	@echo "make lint     - Run RuboCop linter"
-	@echo "make build    - Build Docker image"
-	@echo "make up       - Build and run Docker container on :8080"
-	@echo "make down     - Stop the Docker container"
+	@echo "make run        - Run app locally (Ruby + SQLite)"
+	@echo "make css        - Run Tailwind CSS watcher in background"
+	@echo "make install    - Bundle install dependencies"
+	@echo "make lint       - Run RuboCop linter"
+	@echo "make build      - Build production Docker image"
+	@echo "make up         - Build and run production container on :8080"
+	@echo "make down       - Stop the production container"
+	@echo "make dev        - Start dev stack (web + css watcher + db) on :8080"
+	@echo "make dev-build  - Build dev images only"
+	@echo "make dev-down   - Stop the dev stack"
+	@echo "make dev-logs   - Tail dev stack logs"

--- a/ruby-app/compose.dev.yml
+++ b/ruby-app/compose.dev.yml
@@ -13,10 +13,18 @@ services:
     volumes:
       - postgres_data_dev:/var/lib/postgresql/data
 
+  css:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: bundle exec tailwindcss -i ./public/input.css -o ./public/output.css --watch
+    volumes:
+      - .:/app
+
   web:
     build:
       context: .
-      target: build
+      dockerfile: Dockerfile.dev
     command: bundle exec rerun -- ruby app.rb -o 0.0.0.0 -p 8080
     environment:
       PORT: 8080


### PR DESCRIPTION
### What has changed?
Added a dedicated `Dockerfile.dev`, a Tailwind watcher service in `compose.dev.yml`, and dev targets in the Makefile (`dev`, `dev-build`, `dev-down`, `dev-logs`). Also added the `aarch64-linux-musl` platform to `Gemfile.lock`.

### Why did it need to be changed?
The prod Dockerfile downloaded an x86-only Tailwind binary, which crashed the dev build on Apple Silicon. The team is split across x86 and ARM and needs one setup that works on both.

### How did you change it?
`Dockerfile.dev` skips the hardcoded binary and lets `bundle`/`tailwindcss-ruby` resolve the right native gem per arch. A `css` service runs `tailwindcss --watch` against the mounted source so CSS rebuilds live (the volume mount otherwise hides build-time output).

***

**Checklist**

- [x] Application compiles
- [ ] Documentation added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Commit Atomicity Issue ⚠️

This PR contains **1 commit with 789 files changed** — far exceeding best practices for atomic commits. This massive squash makes review, bisecting, and understanding the specific local dev changes difficult. To demonstrate good DevOps practices in your elective:

**Split into atomic commits:**
1. Local dev setup (Dockerfile.dev + compose.dev.yml + Makefile dev targets)
2. Gemfile.lock platform updates
3. Documentation, CI workflows, and other infrastructure
4. Vendor dependencies (should often be excluded from VCS)

---

## Code Review Issues

### **1. Hardcoded Credentials in compose.dev.yml** ⚠️ SECURITY

Both instances contain plaintext passwords:
```yaml
POSTGRES_PASSWORD: secret
DATABASE_URL: postgres://whoknows:secret@db:5432/whoknows_development
```

**Why this is a problem:** Even in dev, hardcoded credentials establish dangerous habits. If accidentally committed to a shared branch or pushed to a public repo, credentials are exposed. This violates the principle of **Automation** (credentials should be externalized).

**Fix:** Use environment variables from `.env.local`:
```yaml
environment:
  POSTGRES_DB: whoknows_development
  POSTGRES_USER: whoknows
  POSTGRES_PASSWORD: ${POSTGRES_DEV_PASSWORD}
  DATABASE_URL: postgres://whoknows:${POSTGRES_DEV_PASSWORD}`@db`:5432/whoknows_development
```

Create `.env.local` (gitignored) and `.env.example` (committed):
```bash
# .env.example
POSTGRES_DEV_PASSWORD=secret

# .env.local (not committed)
POSTGRES_DEV_PASSWORD=secret
```

Use with: `docker compose --env-file .env.local -f compose.dev.yml up`

Or update the Makefile:
```makefile
dev:
	docker compose --env-file .env.local -f $(DEV_COMPOSE) up -d --build
```

---

### **2. Dockerfile.dev: Build Tools Overhead (Minor)**

Installing `build-base` adds ~150 MB to every dev container rebuild. For local dev this isn't critical, but consider a multi-stage approach if iterations are frequent:

```dockerfile
FROM ruby:3.3-alpine AS builder
RUN apk add --no-cache build-base sqlite-dev postgresql-dev yaml-dev
COPY Gemfile Gemfile.lock* ./
RUN bundle install

FROM ruby:3.3-alpine
RUN apk add --no-cache tzdata sqlite postgresql yaml
COPY --from=builder /usr/local/bundle /usr/local/bundle
WORKDIR /app
COPY . .
EXPOSE 8080
CMD ["bundle", "exec", "rerun", "--", "ruby", "app.rb", "-o", "0.0.0.0", "-p", "8080"]
```

This reduces the final dev image while keeping builder layer cached. Not required but aligns with **Lean** principle.

---

### **3. compose.dev.yml: CSS Service Missing Dependency**

The `css` service mounts the source volume but has no dependency on the `db` healthcheck. While CSS doesn't directly need the database, following explicit service ordering prevents race conditions:

```yaml
css:
  # ... existing config ...
  depends_on:
    db:
      condition: service_healthy
```

This ensures the dev environment starts in a predictable state.

---

## Positive Aspects ✅

- Using `tailwindcss-ruby` gem correctly handles multi-arch without hardcoded x86-only binaries
- Separate `css` service follows **Automation** and **Lean** principles (dedicated process, faster rebuilds)
- Dockerfile.dev avoids production bloat
- Platform-specific gems (aarch64-linux-musl) properly locked in Gemfile.lock
- Makefile help text already documents the :8080 port (good!)
- Health checks on PostgreSQL service

---

## Action Items

**Critical:**
1. Split into atomic commits
2. Move credentials to environment variables

**Recommended:**
3. Add `depends_on: db` to CSS service
4. Update Makefile to pass `--env-file .env.local`

These align with DevOps **Culture** (security-conscious practices), **Automation** (externalized config), and **Lean** (efficient, focused commits).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->